### PR TITLE
grpc: Move /posts/<id> to backend

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,13 @@
             "env": {
                 "PN_JUXTAPOSITION_UI_USE_PRESETS": "docker"
             }
+        },
+        {
+            "type": "node-terminal",
+            "name": "Rebuild gRPC",
+            "request": "launch",
+            "command": "npm rebuild @repo/grpc-client",
+            "cwd": "${workspaceFolder}"
         }
     ],
     "compounds": [

--- a/apps/juxtaposition-ui/package.json
+++ b/apps/juxtaposition-ui/package.json
@@ -26,6 +26,7 @@
     "ejs": "^3.1.10",
     "esbuild-plugin-copy": "^2.1.1",
     "express": "^4.21.2",
+    "express-async-errors": "^3.1.1",
     "express-prom-bundle": "^7.0.2",
     "express-rate-limit": "^7.5.0",
     "express-session": "^1.18.1",

--- a/apps/juxtaposition-ui/package.json
+++ b/apps/juxtaposition-ui/package.json
@@ -50,7 +50,8 @@
     "redis": "^4.7.0",
     "sharp": "^0.33.5",
     "tga": "^1.0.7",
-    "tsx": "^4.19.3"
+    "tsx": "^4.19.3",
+    "zod": "^3.25.56"
   },
   "devDependencies": {
     "@pretendonetwork/eslint-config": "^0.0.8",

--- a/apps/juxtaposition-ui/src/backend.ts
+++ b/apps/juxtaposition-ui/src/backend.ts
@@ -1,0 +1,10 @@
+import { apiFetchUser } from '@/fetch';
+import { PostSchema } from '@/models/api/post';
+import type { UserTokens } from '@/fetch';
+import type { Post } from '@/models/api/post';
+
+export async function getPostById(tokens: UserTokens, post_id: string): Promise<Post> {
+	const data = await apiFetchUser(tokens, `/api/v1/posts/${post_id}`);
+	const post = await PostSchema.parseAsync(data); // todo: what to do on validation fail..?
+	return post;
+}

--- a/apps/juxtaposition-ui/src/fetch.ts
+++ b/apps/juxtaposition-ui/src/fetch.ts
@@ -31,6 +31,7 @@ export async function apiFetch<T>(path: string, options?: FetchOptions): Promise
 		metadata
 	});
 
+	// TODO don't throw away the response payload here
 	if (isErrorHttpStatus(response.status)) {
 		throw new Error(`HTTP error! status: ${response.status}`);
 	}

--- a/apps/juxtaposition-ui/src/fetch.ts
+++ b/apps/juxtaposition-ui/src/fetch.ts
@@ -31,10 +31,21 @@ export async function apiFetch<T>(path: string, options?: FetchOptions): Promise
 		metadata
 	});
 
-	// TODO don't throw away the response payload here
 	if (isErrorHttpStatus(response.status)) {
-		throw new Error(`HTTP error! status: ${response.status}`);
+		throw new Error(`HTTP error! status: ${response.status} ${response.payload}`);
 	}
 
 	return JSON.parse(response.payload) as T;
+}
+
+export async function apiFetchUser<T>(request: any, path: string, options?: FetchOptions): Promise<T> {
+	options = {
+		...options,
+		headers: {
+			'x-service-token': request.serviceToken,
+			'x-oauth-token': request.token,
+			...options?.headers
+		}
+	};
+	return apiFetch<T>(path, options);
 }

--- a/apps/juxtaposition-ui/src/fetch.ts
+++ b/apps/juxtaposition-ui/src/fetch.ts
@@ -20,12 +20,12 @@ export async function apiFetch<T>(path: string, options?: FetchOptions): Promise
 	};
 
 	const metadata = Metadata({
-		...defaultedOptions.headers,
 		'X-API-Key': config.grpc.miiverse.apiKey
 	});
 	const response = await grpcClient.sendPacket({
 		path,
 		method: defaultedOptions.method,
+		headers: JSON.stringify(defaultedOptions.headers),
 		payload: defaultedOptions.body ? JSON.stringify(defaultedOptions.body) : undefined
 	}, {
 		metadata

--- a/apps/juxtaposition-ui/src/middleware/consoleAuth.js
+++ b/apps/juxtaposition-ui/src/middleware/consoleAuth.js
@@ -7,15 +7,15 @@ async function auth(request, response, next) {
 	if (request.session && request.session.user && request.session.pid && !request.isWrite) {
 		request.user = request.session.user;
 		request.pid = request.session.pid;
-		request.serviceToken = request.session.serviceToken;
+		request.tokens = request.session.tokens;
 	} else {
+		request.tokens = { serviceToken: request.headers['x-nintendo-servicetoken'] };
 		request.pid = request.headers['x-nintendo-servicetoken'] ? await util.processServiceToken(request.headers['x-nintendo-servicetoken']) : null;
 		request.user = request.pid ? await util.getUserDataFromPid(request.pid) : null;
-		request.serviceToken = request.headers['x-nintendo-servicetoken'];
 
 		request.session.user = request.user;
 		request.session.pid = request.pid;
-		request.session.serviceToken = request.serviceToken;
+		request.session.tokens = request.tokens;
 	}
 
 	// Set headers

--- a/apps/juxtaposition-ui/src/middleware/consoleAuth.js
+++ b/apps/juxtaposition-ui/src/middleware/consoleAuth.js
@@ -7,12 +7,15 @@ async function auth(request, response, next) {
 	if (request.session && request.session.user && request.session.pid && !request.isWrite) {
 		request.user = request.session.user;
 		request.pid = request.session.pid;
+		request.serviceToken = request.session.serviceToken;
 	} else {
 		request.pid = request.headers['x-nintendo-servicetoken'] ? await util.processServiceToken(request.headers['x-nintendo-servicetoken']) : null;
 		request.user = request.pid ? await util.getUserDataFromPid(request.pid) : null;
+		request.serviceToken = request.headers['x-nintendo-servicetoken'];
 
 		request.session.user = request.user;
 		request.session.pid = request.pid;
+		request.session.serviceToken = request.serviceToken;
 	}
 
 	// Set headers

--- a/apps/juxtaposition-ui/src/middleware/webAuth.js
+++ b/apps/juxtaposition-ui/src/middleware/webAuth.js
@@ -31,7 +31,7 @@ async function webAuth(request, response, next) {
 		}
 	}
 
-	request.token = request.cookies.access_token;
+	request.tokens = { oauthToken: request.cookies.access_token };
 
 	// Open access pages
 	if (isStartOfPath(request.path, '/users/') ||

--- a/apps/juxtaposition-ui/src/middleware/webAuth.js
+++ b/apps/juxtaposition-ui/src/middleware/webAuth.js
@@ -24,7 +24,7 @@ async function webAuth(request, response, next) {
 			response.clearCookie('token_type', { domain: cookieDomain, path: '/' });
 			if (request.path === '/login') {
 				response.locals.lang = util.processLanguage();
-				request.token = request.cookies.access_token;
+				request.tokens = {};
 				request.paramPackData = null;
 				return next();
 			}

--- a/apps/juxtaposition-ui/src/models/api/post.ts
+++ b/apps/juxtaposition-ui/src/models/api/post.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+const zBoolNumber = z.union([z.literal(0), z.literal(1)]);
+// there are exactly two posts (of 550K) in the DB with IDs that are not 21 chars
+const zPostId = z.string().min(19).max(22);
+/* This schema (specifically the types and optionals) is trying to be 1:1 to the existing MongoDB,
+ * with the intent that we can incrementally fix it as the db is improved.
+ * The intent is to not do any transformation here, yet.
+ */
+export const PostSchema = z.object({
+	id: zPostId,
+	title_id: z.string().optional(), // u64
+	screen_name: z.string(),
+	body: z.string(),
+	app_data: z.string().optional(), // TODO nintendo base64
+
+	// base64, '' for posts without, undef for PMs
+	painting: z.string().optional(),
+	// URL fragment, '' for posts without, undef for PMs
+	screenshot: z.union([z.literal(''), z.string().startsWith('/')]).optional(),
+	screenshot_length: z.number().optional(),
+
+	// sometimes missing, sometimes empty
+	search_key: z.array(z.string()).optional(),
+	// sometimes missing, sometimes empty
+	topic_tag: z.string().optional(),
+
+	community_id: z.string(), // i64?
+	created_at: z.coerce.date(),
+	// missing on PMs
+	feeling_id: z.number().optional(), // todo enum
+
+	is_autopost: zBoolNumber, // boolean
+	is_community_private_autopost: zBoolNumber, // boolean
+	is_spoiler: zBoolNumber, // boolean
+	is_app_jumpable: zBoolNumber, // boolean
+
+	empathy_count: z.number().nonnegative(),
+	country_id: z.number(),
+	language_id: z.number(),
+
+	mii: z.string(), // .base64(), TODO nintendo base64
+	mii_face_url: z.string().url(),
+
+	pid: z.number(),
+	platform_id: z.number().optional(), // missing on PMs
+	region_id: z.number().optional(), // missing on PMs
+	parent: zPostId.optional().nullable(), // both missing and null exist
+
+	reply_count: z.number().nonnegative(),
+	verified: z.boolean(),
+
+	message_to_pid: z.number().nullable(),
+	removed: z.boolean(),
+	removed_by: z.number().optional(), // pid
+	removed_at: z.coerce.date().optional(),
+	removed_reason: z.string().optional(),
+	yeahs: z.array(z.number())
+});
+
+export type Post = z.infer<typeof PostSchema>;

--- a/apps/juxtaposition-ui/src/server.js
+++ b/apps/juxtaposition-ui/src/server.js
@@ -76,23 +76,29 @@ app.use(juxt_web);
 logger.info('Creating 404 status handler');
 app.use((req, res) => {
 	req.log.warn('Page not found');
+	res.status(404);
 	res.render(req.directory + '/error.ejs', {
 		code: 404,
-		message: 'Page not found'
+		message: 'Page not found',
+		id: req.id
 	});
 });
 
 // non-404 error handler
 logger.info('Creating non-404 status handler');
-app.use((error, request, response) => {
+app.use((error, req, res, next) => {
+	if (res.headersSent) {
+		return next(error);
+	}
+
 	const status = error.status || 500;
+	res.status(status);
 
-	response.status(status);
-
-	response.json({
-		app: 'api',
-		status,
-		error: error.message
+	req.log.error(error, 'Request failed!');
+	res.render(req.directory + '/error.ejs', {
+		code: status,
+		message: 'Error',
+		id: req.id
 	});
 });
 

--- a/apps/juxtaposition-ui/src/server.js
+++ b/apps/juxtaposition-ui/src/server.js
@@ -95,7 +95,7 @@ app.use((error, req, res, next) => {
 	if (error.status === 401) {
 		req.session.user = undefined;
 		req.session.pid = undefined;
-		return res.redirect('/login');
+		return res.redirect(`/login?redirect=${req.originalUrl}`);
 	}
 
 	const status = error.status || 500;

--- a/apps/juxtaposition-ui/src/server.js
+++ b/apps/juxtaposition-ui/src/server.js
@@ -3,6 +3,7 @@ const cookieParser = require('cookie-parser');
 const session = require('express-session');
 const { RedisStore } = require('connect-redis');
 const expressMetrics = require('express-prom-bundle');
+require('express-async-errors'); // See package docs
 const database = require('@/database');
 const { logger } = require('@/logger');
 const { loggerHttp } = require('@/loggerHttp');

--- a/apps/juxtaposition-ui/src/server.js
+++ b/apps/juxtaposition-ui/src/server.js
@@ -91,6 +91,13 @@ app.use((error, req, res, next) => {
 		return next(error);
 	}
 
+	// small hack because token expiry is weird
+	if (error.status === 401) {
+		req.session.user = undefined;
+		req.session.pid = undefined;
+		return res.redirect('/login');
+	}
+
 	const status = error.status || 500;
 	res.status(status);
 

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.js
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.js
@@ -12,6 +12,7 @@ const upload = multer({ dest: 'uploads/' });
 const redis = require('@/redisCache');
 const { config } = require('@/config');
 const router = express.Router();
+const { apiFetchUser } = require('@/fetch');
 
 const postLimit = rateLimit({
 	windowMs: 15 * 1000, // 30 seconds
@@ -108,7 +109,7 @@ router.post('/new', postLimit, upload.none(), async function (req, res) {
 router.get('/:post_id', async function (req, res) {
 	const userSettings = await database.getUserSettings(req.pid);
 	const userContent = await database.getUserContent(req.pid);
-	let post = await database.getPostByID(req.params.post_id.toString());
+	let post = await apiFetchUser(req, `/api/v1/posts/${req.params.post_id}`);
 	if (post === null) {
 		return res.redirect('/404');
 	}

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.js
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.js
@@ -114,7 +114,7 @@ router.get('/:post_id', async function (req, res) {
 		return res.redirect('/404');
 	}
 	if (post.parent) {
-		post = await database.getPostByID(post.parent);
+		post = await apiFetchUser(req, `/api/v1/posts/${post.parent}`);
 		if (post === null) {
 			return res.sendStatus(404);
 		}

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/web/login.js
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/web/login.js
@@ -8,22 +8,22 @@ const { logger } = require('@/logger');
 const cookieDomain = config.http.cookieDomain;
 
 router.get('/', async function (req, res) {
-	res.render(req.directory + '/login.ejs', { toast: null });
+	res.render(req.directory + '/login.ejs', { toast: null, redirect: req.query.redirect ?? '/' });
 });
 
 router.post('/', async (req, res) => {
-	const { username, password } = req.body;
+	const { username, password, redirect } = req.body;
 	const login = await util.login(username, password).catch((e) => {
 		switch (e.details) {
 			case 'INVALID_ARGUMENT: User not found':
-				res.render(req.directory + '/login.ejs', { toast: 'Username was invalid.' });
+				res.render(req.directory + '/login.ejs', { toast: 'Username was invalid.', redirect });
 				break;
 			case 'INVALID_ARGUMENT: Password is incorrect':
-				res.render(req.directory + '/login.ejs', { toast: 'Password was incorrect.' });
+				res.render(req.directory + '/login.ejs', { toast: 'Password was incorrect.', redirect });
 				break;
 			default:
 				logger.error(e, `Login error for ${username}`);
-				res.render(req.directory + '/login.ejs', { toast: 'Invalid username or password.' });
+				res.render(req.directory + '/login.ejs', { toast: 'Invalid username or password.', redirect });
 				break;
 		}
 	});
@@ -33,7 +33,7 @@ router.post('/', async (req, res) => {
 
 	const PNID = await util.getUserDataFromToken(login.accessToken);
 	if (!PNID) {
-		return res.render(req.directory + '/login.ejs', { toast: 'Invalid username or password.' });
+		return res.render(req.directory + '/login.ejs', { toast: 'Invalid username or password.', redirect });
 	}
 
 	let discovery = await database.getEndPoint(config.serverEnvironment);
@@ -65,7 +65,7 @@ router.post('/', async (req, res) => {
 	res.cookie('access_token', login.accessToken, { domain: cookieDomain, maxAge: expiration });
 	res.cookie('refresh_token', login.refreshToken, { domain: cookieDomain });
 	res.cookie('token_type', 'Bearer', { domain: cookieDomain });
-	res.redirect('/');
+	res.redirect(redirect);
 });
 
 module.exports = router;

--- a/apps/juxtaposition-ui/src/webfiles/web/error.ejs
+++ b/apps/juxtaposition-ui/src/webfiles/web/error.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <!-- general -->
-    <title>Juxtaposition Log In</title>
+    <title>Juxt - Error</title>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="manifest" href="/web/manifest.json">
@@ -67,7 +67,9 @@
                 </svg>
             </a>
             <h2><%= code %>: <%= message %></h2>
-            <h3>View current server status <a href="https://stats.uptimerobot.com/R7E4wiGjJq">here.</a></h3>
+            <h3>View current <a href="https://stats.uptimerobot.com/R7E4wiGjJq">server status</a>.</h3>
+            <h3>Or, <a href="/">go back to the homepage</a>.</h3>
+            <p>Request ID: <%= id %></p>
         </div>
     </div>
 </div>

--- a/apps/juxtaposition-ui/src/webfiles/web/login.ejs
+++ b/apps/juxtaposition-ui/src/webfiles/web/login.ejs
@@ -83,6 +83,7 @@
                     <button type="submit">Login</button>
                     <a href="https://pretendo.network/account/register" class="register">Don't have an account?</a>
                 </div>
+                <input type="hidden" name="redirect" value="<%= redirect %>">
             </form>
         </div>
     </div>

--- a/apps/miiverse-api/package.json
+++ b/apps/miiverse-api/package.json
@@ -21,6 +21,7 @@
 		"colors": "^1.4.0",
 		"crc": "^4.3.2",
 		"express": "^4.17.1",
+		"express-async-errors": "^3.1.1",
 		"express-prom-bundle": "^7.0.2",
 		"express-subdomain": "^1.0.5",
 		"fs-extra": "^9.0.0",

--- a/apps/miiverse-api/src/errors.ts
+++ b/apps/miiverse-api/src/errors.ts
@@ -74,30 +74,10 @@ function sendXMLError(response: express.Response, errorCode: ApiErrorCode, httpC
 	}).end({ pretty: true }));
 }
 
-function sendJSONError(response: express.Response, errorCode: ApiErrorCode, httpCode: number): void {
-	response.status(httpCode);
-	// Save this for the logger
-	response.errorCode = errorCode;
-
-	// TODO actually design this object
-	response.json({
-		error_code: errorCode,
-		message: ApiErrorCode[errorCode]
-	});
-}
-
 export function badRequest(response: express.Response, errorCode: number, httpCode: number = 400): void {
 	return sendXMLError(response, errorCode, httpCode);
 }
 
 export function serverError(response: express.Response, errorCode: ApiErrorCode, httpCode: number = 500): void {
 	return sendXMLError(response, errorCode, httpCode);
-}
-
-export function badRequestV2(response: express.Response, errorCode: number, httpCode: number = 400): void {
-	return sendJSONError(response, errorCode, httpCode);
-}
-
-export function serverErrorV2(response: express.Response, errorCode: ApiErrorCode, httpCode: number = 500): void {
-	return sendJSONError(response, errorCode, httpCode);
 }

--- a/apps/miiverse-api/src/errors.ts
+++ b/apps/miiverse-api/src/errors.ts
@@ -57,7 +57,7 @@ export enum ApiErrorCode {
 	FAIL_POST_NOCOMMENT = 935
 }
 
-function sendError(response: express.Response, errorCode: ApiErrorCode, httpCode: number): void {
+function sendXMLError(response: express.Response, errorCode: ApiErrorCode, httpCode: number): void {
 	response.type('application/xml');
 	response.status(httpCode);
 	// Save this for the logger
@@ -74,10 +74,30 @@ function sendError(response: express.Response, errorCode: ApiErrorCode, httpCode
 	}).end({ pretty: true }));
 }
 
+function sendJSONError(response: express.Response, errorCode: ApiErrorCode, httpCode: number): void {
+	response.status(httpCode);
+	// Save this for the logger
+	response.errorCode = errorCode;
+
+	// TODO actually design this object
+	response.json({
+		error_code: errorCode,
+		message: ApiErrorCode[errorCode]
+	});
+}
+
 export function badRequest(response: express.Response, errorCode: number, httpCode: number = 400): void {
-	return sendError(response, errorCode, httpCode);
+	return sendXMLError(response, errorCode, httpCode);
 }
 
 export function serverError(response: express.Response, errorCode: ApiErrorCode, httpCode: number = 500): void {
-	return sendError(response, errorCode, httpCode);
+	return sendXMLError(response, errorCode, httpCode);
+}
+
+export function badRequestV2(response: express.Response, errorCode: number, httpCode: number = 400): void {
+	return sendJSONError(response, errorCode, httpCode);
+}
+
+export function serverErrorV2(response: express.Response, errorCode: ApiErrorCode, httpCode: number = 500): void {
+	return sendJSONError(response, errorCode, httpCode);
 }

--- a/apps/miiverse-api/src/middleware/authv2.ts
+++ b/apps/miiverse-api/src/middleware/authv2.ts
@@ -1,0 +1,24 @@
+import { ApiErrorCode, badRequestV2 } from '@/errors';
+import { getValueFromHeaders } from '@/util';
+import type express from 'express';
+
+async function auth(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
+	const serviceToken = getValueFromHeaders(request.headers, 'x-service-token');
+	const oAuthToken = getValueFromHeaders(request.headers, 'x-oauth-token');
+
+	if (serviceToken && oAuthToken) {
+		return badRequestV2(response, ApiErrorCode.BAD_TOKEN);
+	}
+
+	if (serviceToken) {
+		// TODO
+	} else if (oAuthToken) {
+		// TODO
+	} else {
+		return badRequestV2(response, ApiErrorCode.BAD_TOKEN);
+	}
+
+	return next();
+}
+
+export default auth;

--- a/apps/miiverse-api/src/server.ts
+++ b/apps/miiverse-api/src/server.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import 'express-async-errors'; // See package docs
 import expressMetrics from 'express-prom-bundle';
 import { connect as connectDatabase } from '@/database';
 import { logger } from '@/logger';

--- a/apps/miiverse-api/src/services/internal/errors.ts
+++ b/apps/miiverse-api/src/services/internal/errors.ts
@@ -1,0 +1,16 @@
+export class InternalAPIError extends Error {
+	status: number;
+
+	constructor(status: number, message?: string) {
+		super(message);
+		this.status = status;
+	}
+}
+
+export const errors = {
+	badRequest: InternalAPIError.bind(null, 400),
+	unauthorized: InternalAPIError.bind(null, 401),
+	forbidden: InternalAPIError.bind(null, 403),
+
+	serverError: InternalAPIError.bind(null, 500)
+};

--- a/apps/miiverse-api/src/services/internal/errors.ts
+++ b/apps/miiverse-api/src/services/internal/errors.ts
@@ -11,6 +11,7 @@ export const errors = {
 	badRequest: InternalAPIError.bind(null, 400),
 	unauthorized: InternalAPIError.bind(null, 401),
 	forbidden: InternalAPIError.bind(null, 403),
+	notFound: InternalAPIError.bind(null, 404),
 
 	serverError: InternalAPIError.bind(null, 500)
 };

--- a/apps/miiverse-api/src/services/internal/index.ts
+++ b/apps/miiverse-api/src/services/internal/index.ts
@@ -1,5 +1,7 @@
 import express from 'express';
 import { testRouter } from '@/services/internal/routes/test';
+import { postsRouter } from '@/services/internal/routes/posts';
 
 export const internalApiRouter = express.Router();
 internalApiRouter.use('/api/v1', testRouter);
+internalApiRouter.use('/api/v1/posts', postsRouter);

--- a/apps/miiverse-api/src/services/internal/middleware/authenticated-endpoints.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/authenticated-endpoints.ts
@@ -1,0 +1,39 @@
+import { errors } from '@/services/internal/errors';
+import type express from 'express';
+
+/**
+ * Guest access is fine
+ */
+export async function authGuest(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
+	return next();
+}
+
+/**
+ * Fail on guest access
+ */
+export async function authUsers(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
+	const account = response.locals.account;
+	if (account === null) {
+		// Guest access
+		throw new errors.unauthorized('Authentication token not provided');
+	}
+
+	return next();
+}
+
+/**
+ * Moderators only
+ */
+export async function authModerators(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
+	const account = response.locals.account;
+	if (account === null) {
+		// Guest access
+		throw new errors.unauthorized('Authentication token not provided');
+	}
+
+	if (account.pnid.accessLevel < 2) {
+		throw new errors.forbidden('You cannot access this endpoint');
+	}
+
+	return next();
+}

--- a/apps/miiverse-api/src/services/internal/middleware/authentication.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/authentication.ts
@@ -23,7 +23,8 @@ async function auth(request: express.Request, response: express.Response, next: 
 	} else if (oAuthToken) {
 		response.locals.account = await webAuth(oAuthToken);
 	} else {
-		throw new errors.unauthorized('Authentication token not provided');
+		// Guest access
+		response.locals.account = null;
 	}
 
 	return next();

--- a/apps/miiverse-api/src/services/internal/middleware/authentication.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/authentication.ts
@@ -1,24 +1,58 @@
-import { getValueFromHeaders } from '@/util';
+import { getPIDFromServiceToken, getUserAccountData, getUserDataFromToken, getValueFromHeaders } from '@/util';
 import { errors } from '@/services/internal/errors';
+import { getUserSettings } from '@/database';
 import type express from 'express';
+import type { AccountData } from '@/types/common/account-data';
 
 async function auth(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
+	// Used by console applets
 	const serviceToken = getValueFromHeaders(request.headers, 'x-service-token');
+	// Used by web frontend
 	const oAuthToken = getValueFromHeaders(request.headers, 'x-oauth-token');
 
 	if (serviceToken && oAuthToken) {
-		next(new errors.badRequest('Multiple authentication tokens provided'));
+		throw new errors.badRequest('Multiple authentication tokens provided');
 	}
 
 	if (serviceToken) {
-		// TODO
+		response.locals.account = await consoleAuth(serviceToken);
 	} else if (oAuthToken) {
-		// TODO
+		response.locals.account = await webAuth(oAuthToken);
 	} else {
-		return next(new errors.unauthorized('Authentication token not provided'));
+		throw new errors.unauthorized('Authentication token not provided');
 	}
 
 	return next();
+}
+
+async function consoleAuth(serviceToken: string): Promise<AccountData> {
+	const pid = getPIDFromServiceToken(serviceToken);
+	if (pid === 0) {
+		throw new errors.unauthorized('Invalid service token');
+	}
+
+	const pnid = await getUserAccountData(pid);
+	// If the user has a valid token for an unknown PID, just let the exception bubble
+
+	const settings = await getUserSettings(pid) ?? undefined; // Null doesn't play nice with TS ?
+	// Undef here just means the initial setup isn't done
+
+	return { pnid, settings };
+}
+
+async function webAuth(oAuthToken: string): Promise<AccountData> {
+	// The "normal" getUserData API (used here) is mutually incompatible with the "backdoor" one.
+	// Since we can only use the backdoor one for consoles right now...
+	const pid = (await getUserDataFromToken(oAuthToken).catch(() => {
+		// TODO should probably check the error type here in case of e.g. connection refused
+		throw new errors.unauthorized('Invalid OAuth token!');
+	})).pid;
+	// Ask the "backdoor" API, just use the above as a glorified token decryption.
+	const pnid = await getUserAccountData(pid);
+
+	const settings = await getUserSettings(pid) ?? undefined;
+
+	return { pnid, settings };
 }
 
 export default auth;

--- a/apps/miiverse-api/src/services/internal/middleware/authentication.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/authentication.ts
@@ -1,5 +1,5 @@
-import { ApiErrorCode, badRequestV2 } from '@/errors';
 import { getValueFromHeaders } from '@/util';
+import { errors } from '@/services/internal/errors';
 import type express from 'express';
 
 async function auth(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
@@ -7,7 +7,7 @@ async function auth(request: express.Request, response: express.Response, next: 
 	const oAuthToken = getValueFromHeaders(request.headers, 'x-oauth-token');
 
 	if (serviceToken && oAuthToken) {
-		return badRequestV2(response, ApiErrorCode.BAD_TOKEN);
+		next(new errors.badRequest('Multiple authentication tokens provided'));
 	}
 
 	if (serviceToken) {
@@ -15,7 +15,7 @@ async function auth(request: express.Request, response: express.Response, next: 
 	} else if (oAuthToken) {
 		// TODO
 	} else {
-		return badRequestV2(response, ApiErrorCode.BAD_TOKEN);
+		return next(new errors.unauthorized('Authentication token not provided'));
 	}
 
 	return next();

--- a/apps/miiverse-api/src/services/internal/middleware/authentication.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/authentication.ts
@@ -4,6 +4,10 @@ import { getUserSettings } from '@/database';
 import type express from 'express';
 import type { AccountData } from '@/types/common/account-data';
 
+/**
+ * Handles authentication for service (NNAS/console) and OAuth (web) tokens. Sets locals.account to AccountData.
+ * Will error if tokens bad or account nonexistent, but otherwise does not check bans or setup status.
+ */
 async function auth(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
 	// Used by console applets
 	const serviceToken = getValueFromHeaders(request.headers, 'x-service-token');

--- a/apps/miiverse-api/src/services/internal/middleware/check-user-account.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/check-user-account.ts
@@ -1,12 +1,15 @@
 import { errors } from '@/services/internal/errors';
 import type express from 'express';
-import type { AccountData } from '@/types/common/account-data';
 
 /**
  * Checks the user account is valid for this request (not banned, setup complete, etc.)
  */
 async function checkUserAccount(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
-	const account = response.locals!.account as AccountData;
+	const account = response.locals.account;
+	if (account === null) {
+		// Guest access
+		return next();
+	}
 
 	if (account.pnid.accessLevel < 0) {
 		throw new errors.unauthorized('Account has been banned');

--- a/apps/miiverse-api/src/services/internal/middleware/check-user-account.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/check-user-account.ts
@@ -1,0 +1,20 @@
+import { errors } from '@/services/internal/errors';
+import type express from 'express';
+import type { AccountData } from '@/types/common/account-data';
+
+/**
+ * Checks the user account is valid for this request (not banned, setup complete, etc.)
+ */
+async function checkUserAccount(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
+	const account = response.locals!.account as AccountData;
+
+	if (account.pnid.accessLevel < 0) {
+		throw new errors.unauthorized('Account has been banned');
+	}
+
+	// TODO account settings, temp bans, etc.
+
+	return next();
+}
+
+export default checkUserAccount;

--- a/apps/miiverse-api/src/services/internal/routes/posts.ts
+++ b/apps/miiverse-api/src/services/internal/routes/posts.ts
@@ -2,10 +2,11 @@ import express from 'express';
 import { getPostByID } from '@/database';
 import { errors } from '@/services/internal/errors';
 import { handle } from '@/services/internal/utils';
+import { authGuest } from '@/services/internal/middleware/authenticated-endpoints';
 
 export const postsRouter = express.Router();
 
-postsRouter.get('/:post_id', handle(async ({ req }) => {
+postsRouter.get('/:post_id', authGuest, handle(async ({ req }) => {
 	const post = await getPostByID(req.params.post_id);
 	if (!post || post.removed) {
 		throw new errors.notFound('Post not found');

--- a/apps/miiverse-api/src/services/internal/routes/posts.ts
+++ b/apps/miiverse-api/src/services/internal/routes/posts.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import { getPostByID } from '@/database';
+import { errors } from '@/services/internal/errors';
+import { handle } from '@/services/internal/utils';
+
+export const postsRouter = express.Router();
+
+postsRouter.get('/:post_id', handle(async ({ req }) => {
+	const post = await getPostByID(req.params.post_id);
+	if (!post || post.removed) {
+		throw new errors.notFound('Post not found');
+	}
+
+	return post;
+}));

--- a/apps/miiverse-api/src/services/internal/routes/test.ts
+++ b/apps/miiverse-api/src/services/internal/routes/test.ts
@@ -1,9 +1,10 @@
 import express from 'express';
 import { handle } from '@/services/internal/utils';
+import { authUsers } from '@/services/internal/middleware/authenticated-endpoints';
 
 export const testRouter = express.Router();
 
-testRouter.get('/test', handle(async () => {
+testRouter.get('/test', authUsers, handle(async () => {
 	return {
 		message: 'Hello from the test route!'
 	};

--- a/apps/miiverse-api/src/services/internal/server.ts
+++ b/apps/miiverse-api/src/services/internal/server.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import { MiiverseServiceDefinition } from '@repo/grpc-client/out/miiverse_service';
 import { config } from '@/config';
 import { internalApiRouter } from '@/services/internal';
+import authv2 from '@/middleware/authv2';
 import { logger } from '@/logger';
 import type { CallContext, ServerMiddlewareCall } from 'nice-grpc';
 
@@ -22,6 +23,7 @@ export async function* apiKeyMiddleware<Request, Response>(
 
 const app = express();
 app.use(express.json());
+app.use(authv2);
 app.use(internalApiRouter);
 
 const allowedMethods = ['get', 'post', 'put', 'delete', 'patch'] as const;

--- a/apps/miiverse-api/src/services/internal/server.ts
+++ b/apps/miiverse-api/src/services/internal/server.ts
@@ -37,9 +37,10 @@ export async function setupGrpc(): Promise<void> {
 				throw new ServerError(Status.UNIMPLEMENTED, 'Method not implemented');
 			}
 			const method = request.method.toLowerCase() as AllowedMethods;
+			const headers = JSON.parse(request.headers);
 			const hasBody = methodsWithBody.includes(method as any);
 
-			let baseRequest = superRequest(app)[method](request.path);
+			let baseRequest = superRequest(app)[method](request.path).set(headers);
 			if (hasBody) {
 				baseRequest = baseRequest.send(JSON.parse(request.payload));
 			}

--- a/apps/miiverse-api/src/services/internal/server.ts
+++ b/apps/miiverse-api/src/services/internal/server.ts
@@ -5,6 +5,7 @@ import { MiiverseServiceDefinition } from '@repo/grpc-client/out/miiverse_servic
 import { config } from '@/config';
 import { internalApiRouter } from '@/services/internal';
 import authentication from '@/services/internal/middleware/authentication';
+import checkUserAccount from '@/services/internal/middleware/check-user-account';
 import { logger } from '@/logger';
 import { InternalAPIError } from '@/services/internal/errors';
 import { loggerHttp } from '@/loggerHttp';
@@ -16,6 +17,7 @@ const app = express();
 app.use(express.json());
 app.use(loggerHttp);
 app.use(authentication);
+app.use(checkUserAccount);
 app.use(internalApiRouter);
 
 // API error handler

--- a/apps/miiverse-api/src/services/internal/utils.ts
+++ b/apps/miiverse-api/src/services/internal/utils.ts
@@ -1,4 +1,3 @@
-import { logger } from '@/logger';
 import type { Request, Response } from 'express';
 
 export type HandlerContext = {
@@ -10,15 +9,8 @@ export type HandlerFunction = (ctx: HandlerContext) => any;
 
 export function handle(handler: HandlerFunction) {
 	return async (req: Request, res: Response): Promise<void> => {
-		try {
-			const ctx: HandlerContext = { req, res };
-			const result = await handler(ctx);
-			res.status(200).json(result);
-			return;
-		} catch (error) {
-			logger.error(error, 'Unhandled exception in handler');
-			res.status(500).json({ error: 'Internal Server Error' });
-			return;
-		}
+		const ctx: HandlerContext = { req, res };
+		const result = await handler(ctx);
+		res.status(200).json(result);
 	};
 }

--- a/apps/miiverse-api/src/services/internal/utils.ts
+++ b/apps/miiverse-api/src/services/internal/utils.ts
@@ -16,7 +16,7 @@ export function handle(handler: HandlerFunction) {
 			res.status(200).json(result);
 			return;
 		} catch (error) {
-			logger.error('Unhandled exception in handler', error);
+			logger.error(error, 'Unhandled exception in handler');
 			res.status(500).json({ error: 'Internal Server Error' });
 			return;
 		}

--- a/apps/miiverse-api/src/types/common/account-data.ts
+++ b/apps/miiverse-api/src/types/common/account-data.ts
@@ -1,0 +1,7 @@
+import type { HydratedSettingsDocument } from '@/types/mongoose/settings';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+
+export interface AccountData {
+	pnid: GetUserDataResponse;
+	settings?: HydratedSettingsDocument;
+}

--- a/apps/miiverse-api/src/types/express.d.ts
+++ b/apps/miiverse-api/src/types/express.d.ts
@@ -1,6 +1,7 @@
 import type { ParamPack } from '@/types/common/param-pack';
 import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
 import type { ApiErrorCode } from '@/errors';
+import type { AccountData } from '@/types/common/account-data';
 
 declare global {
 	namespace Express {
@@ -12,6 +13,10 @@ declare global {
 		}
 		interface Response {
 			errorCode?: ApiErrorCode;
+		}
+		// Locals used in internal/grpc
+		interface Locals {
+			account: AccountData | null;
 		}
 	}
 }

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -8,10 +8,12 @@ import { createChannel, createClient, Metadata } from 'nice-grpc';
 import crc32 from 'crc/crc32';
 import { FriendsDefinition } from '@pretendonetwork/grpc/friends/friends_service';
 import { AccountDefinition } from '@pretendonetwork/grpc/account/account_service';
+import { APIDefinition } from '@pretendonetwork/grpc/api/api_service';
 import { config } from '@/config';
 import { logger } from '@/logger';
 import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/get_user_data_rpc';
 import type { ParsedQs } from 'qs';
 import type { IncomingHttpHeaders } from 'node:http';
 import type { ParamPack } from '@/types/common/param-pack';
@@ -23,6 +25,9 @@ const gRPCFriendsClient = createClient(FriendsDefinition, gRPCFriendsChannel);
 
 const gRPCAccountChannel = createChannel(`${config.grpc.account.host}:${config.grpc.account.port}`);
 const gRPCAccountClient = createClient(AccountDefinition, gRPCAccountChannel);
+
+const gRPCApiChannel = createChannel(`${config.grpc.account.host}:${config.grpc.account.port}`);
+const gRPCApiClient = createClient(APIDefinition, gRPCApiChannel);
 
 const s3 = new aws.S3({
 	endpoint: new aws.Endpoint(config.s3.endpoint),
@@ -186,12 +191,21 @@ export async function getUserFriendRequestsIncoming(pid: number): Promise<Friend
 	return response.friendRequests;
 }
 
-export function getUserAccountData(pid: number): Promise<GetUserDataResponse> {
+export function getUserAccountData(pid: number): Promise<AccountGetUserDataResponse> {
 	return gRPCAccountClient.getUserData({
 		pid: pid
 	}, {
 		metadata: Metadata({
 			'X-API-Key': config.grpc.account.apiKey
+		})
+	});
+}
+
+export function getUserDataFromToken(token: string): Promise<ApiGetUserDataResponse> {
+	return gRPCApiClient.getUserData({}, {
+		metadata: Metadata({
+			'X-API-Key': config.grpc.account.apiKey,
+			'X-Token': token
 		})
 	});
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,8 @@
                 "redis": "^4.7.0",
                 "sharp": "^0.33.5",
                 "tga": "^1.0.7",
-                "tsx": "^4.19.3"
+                "tsx": "^4.19.3",
+                "zod": "^3.25.56"
             },
             "devDependencies": {
                 "@pretendonetwork/eslint-config": "^0.0.8",
@@ -13837,9 +13838,10 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.24.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.4.tgz",
-            "integrity": "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==",
+            "version": "3.25.56",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+            "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+            "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,6 +79,7 @@
                 "colors": "^1.4.0",
                 "crc": "^4.3.2",
                 "express": "^4.17.1",
+                "express-async-errors": "^3.1.1",
                 "express-prom-bundle": "^7.0.2",
                 "express-subdomain": "^1.0.5",
                 "fs-extra": "^9.0.0",
@@ -7045,6 +7046,15 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-async-errors": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/express-async-errors/-/express-async-errors-3.1.1.tgz",
+            "integrity": "sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==",
+            "license": "ISC",
+            "peerDependencies": {
+                "express": "^4.16.2"
             }
         },
         "node_modules/express-prom-bundle": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "ejs": "^3.1.10",
                 "esbuild-plugin-copy": "^2.1.1",
                 "express": "^4.21.2",
+                "express-async-errors": "^3.1.1",
                 "express-prom-bundle": "^7.0.2",
                 "express-rate-limit": "^7.5.0",
                 "express-session": "^1.18.1",

--- a/protobufs/miiverse/v2/packet.proto
+++ b/protobufs/miiverse/v2/packet.proto
@@ -5,7 +5,8 @@ package miiverse.v2;
 message Packet {
   string path = 1;
   string method = 2;
-  string payload = 3;
+  string headers = 3;
+  string payload = 4;
 }
 
 message PacketResponse {


### PR DESCRIPTION
Part of #112 
Need to submit this before it gets unreviewable

### Changes:

This PR adds the extra infrastructure needed for miiverse-api to act as datasource (authentication, error handling, type conversions, validation etc.) and then moves the "post by id" endpoint (and only this endpoint) to the new backend. A few calls to the old database exist in the frontend since they rely on the Post being a Mongoose object for further DB calls - these will be ported once those further calls are in the API.

- The Endpoint: Just sends the document right out of MongoDB for now.
- Validation: On the frontend side, that document gets passed through a Zod schema. The one I've written (Post) is *descriptive*, not *prescriptive*, made in consultation with the prod database so all the jank of the current DB schema is preserved. This will be useful to make sure changes we make to miiverse-api don't break the frontend.
- Authentication: Either the OAuth token (web), service token (console) or nothing (guest web) are included with requests to the backend as headers. It has middlewares to process these tokens, and also has per-endpoint middlewares to select between guest, user, moderator access. On the frontend side, a "UserTokens" object keeps the current state of things cached and can be blindly passed back into the API, so this doesn't make much mess in the business logic.
- Error handling (API): Errors can be thrown deliberately to get specific HTTP codes (Unauthorized, Forbidden etc.), or can just be general JavaScript errors. I know throwing is a different design to what I had refactored into the Nintendo API, but I think this is nicer again. Maybe I'll re-refactor the Nintendo API. 
- Error handling (frontend): HTTP codes from the backend are thrown and allowed to bubble. The error handlers and rendering are tweaked to work better (instead of sometimes spewing a stacktrace), include the request ID, etc. A special case is included for when the user needs to re-log-in; the frontend is extremely permissive about caching and not re-checking tokens, see also #114 - I'm expecting this might be a problem in prod

I know this is an absolute boatload of infrastructure for a very minimalist endpoint (and even it's missing some things, like the moderator/removed posts override) but hopefully it will serve as a foundation for us to work on top of.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.