### PR TITLE
Feat: 3DS User Settings & Toolbar API

### DIFF
--- a/apps/juxtaposition-ui/src/webfiles/ctr/communities.ejs
+++ b/apps/juxtaposition-ui/src/webfiles/ctr/communities.ejs
@@ -3,7 +3,9 @@
 <%- include('partials/head', { title: lang.global.communities }); %>
 <body>
 <div id="body">
-    <header id="header" class="buttons">
+    <header id="header" class="buttons"
+		data-toolbar-config
+		data-toolbar-active-button="3"
         <h1 id="page-title" class=""><%= lang.global.communities %></h1>
         <a id="header-communities-button" class="right" href="/titles/all" data-pjax="#body"><%= lang.all_communities.text %></a>
     </header>

--- a/apps/juxtaposition-ui/src/webfiles/ctr/communities.ejs
+++ b/apps/juxtaposition-ui/src/webfiles/ctr/communities.ejs
@@ -5,7 +5,7 @@
 <div id="body">
     <header id="header" class="buttons"
 		data-toolbar-config
-		data-toolbar-active-button="3"
+		data-toolbar-active-button="3">
         <h1 id="page-title" class=""><%= lang.global.communities %></h1>
         <a id="header-communities-button" class="right" href="/titles/all" data-pjax="#body"><%= lang.all_communities.text %></a>
     </header>

--- a/apps/juxtaposition-ui/src/webfiles/ctr/css/juxt.css
+++ b/apps/juxtaposition-ui/src/webfiles/ctr/css/juxt.css
@@ -924,3 +924,12 @@ menu.tab-header.no-margin {
 	margin: 4px;
 	padding: 4px;
 }
+
+.settings-list > li {
+    display: inline-block;
+}
+
+p.settings-label {
+	float: left;
+	width: 275px;
+}

--- a/apps/juxtaposition-ui/src/webfiles/ctr/js/juxt.js
+++ b/apps/juxtaposition-ui/src/webfiles/ctr/js/juxt.js
@@ -215,6 +215,64 @@ function initTabs() {
 		});
 	}
 }
+function initToolbarConfigs() {
+	var toolbarConfig = document.querySelector('[data-toolbar-config]');
+	if (!toolbarConfig) {
+		return;
+	}
+	var mode = toolbarConfig.getAttribute('data-toolbar-mode');
+	var message = toolbarConfig.getAttribute('data-toolbar-message');
+	var clickHandle = toolbarConfig.getAttribute('data-toolbar-onclick');
+	var backHandle = toolbarConfig.getAttribute('data-toolbar-onback');
+	var activeButton = toolbarConfig.getAttribute('data-toolbar-active-button');
+	var backgroundMusic = toolbarConfig.getAttribute('data-toolbar-bgm');
+	var backgroundMusicExit = toolbarConfig.getAttribute('data-toolbar-exit-bgm');
+	var sound = toolbarConfig.getAttribute('data-toolbar-sound');
+
+	if (mode) {
+		cave.toolbar_setMode(parseInt(mode));
+	}
+
+	if (message) {
+		cave.toolbar_setWideButtonMessage(message);
+	}
+
+	if (clickHandle) {
+		cave.toolbar_setCallback(8, function () {
+			cave.toolbar_setMode(0);
+			cave.toolbar_setButtonType(0);
+			if (backgroundMusicExit) {
+				cave.snd_playBgm(backgroundMusicExit);
+			}
+			eval(window[clickHandle]).call();
+		});
+	}
+
+	if (backHandle) {
+		function goBackHandle() {
+			cave.toolbar_setMode(0);
+			cave.toolbar_setButtonType(0);
+			if (backgroundMusicExit) {
+				cave.snd_playBgm(backgroundMusicExit);
+			}
+			eval(window[backHandle]).call();
+		}
+		cave.toolbar_setCallback(1, goBackHandle);
+		cave.toolbar_setCallback(99, goBackHandle);
+	}
+
+	if (activeButton) {
+		cave.toolbar_setActiveButton(parseInt(activeButton));
+	}
+
+	if (backgroundMusic) {
+		cave.snd_playBgm(backgroundMusic);
+	}
+
+	if (sound) {
+		cave.snd_playSe(sound);
+	}
+}
 
 function deletePost(post) {
 	var id = post.getAttribute('data-post');
@@ -272,7 +330,6 @@ function stopLoading() {
 	}
 	cave.transition_end();
 	cave.lls_setItem('agree_olv', '1');
-	cave.toolbar_setActiveButton(3);
 	cave.snd_playBgm('BGM_CAVE_MAIN');
 	cave.toolbar_setVisible(true);
 }
@@ -284,6 +341,7 @@ function initAll() {
 	initPostModules();
 	initTabs();
 	checkForUpdates();
+	initToolbarConfigs();
 	pjax.refresh();
 }
 
@@ -412,6 +470,16 @@ function follow(el) {
 	});
 }
 window.follow = follow;
+
+function saveUserSettings() {
+	document.getElementById('submit').click();
+}
+window.saveUserSettings = saveUserSettings;
+function exitUserSettings() {
+	pjax.loadUrl('/users/me');
+	cave.toolbar_setButtonType(1);
+}
+window.exitUserSettings = exitUserSettings;
 
 function POST(url, data, callback) {
 	cave.transition_begin();

--- a/apps/juxtaposition-ui/src/webfiles/ctr/settings.ejs
+++ b/apps/juxtaposition-ui/src/webfiles/ctr/settings.ejs
@@ -3,12 +3,52 @@
 <%- include('partials/head', { title: 'Whoops!' }); %>
 <body>
 <div id="body">
-    <header id="header" class="">
+    <header id="header"
+		data-toolbar-config
+		data-toolbar-mode="1"
+		data-toolbar-message="Save Settings"
+		data-toolbar-onclick="saveUserSettings"
+		data-toolbar-onback="exitUserSettings"
+		data-toolbar-bgm="BGM_CAVE_SETTING"
+		data-toolbar-exit-bgm="BGM_CAVE_MAIN_LOOP_NOWAIT">
         <h1 id="page-title" class="">User Settings</h1>
     </header>
     <div class="body-content tab2-content" id="community-post-list">
-        <p>Howdy! We're not quite done here yet.</p>
-        <p>Check back soon for updates!</p>
+		<div class="tab-body">
+			<form method="post" action="/users/me/settings" id="settings-form">
+				<ul class="list-content-with-icon-column settings-list">
+					<li data-name="profile_comment_visibility" class="scroll">
+						<p class="settings-label"><%= lang.user_settings.show_country %></p>
+						<label class="checkbox-container" for="country">
+							<input type="checkbox" id="country" name="country" value="true" <%if(userSettings.country_visibility) {%>checked="checked"<%}%>>
+							<span class="checkmark"></span>
+						</label>
+					</li>
+					<li data-name="game_skill" class="scroll">
+						<p class="settings-label"><%= lang.user_settings.show_birthday %></p>
+						<label class="checkbox-container" for="birthday">
+							<input type="checkbox" id="birthday" name="birthday" value="true" <%if(userSettings.birthday_visibility) {%>checked="checked"<%}%>>
+							<span class="checkmark"></span>
+						</label>
+					</li>
+					<li data-name="game_skill_visibility" class="scroll">
+						<p class="settings-label"><%= lang.user_settings.show_game %></p>
+						<label class="checkbox-container" for="experience">
+							<input type="checkbox" id="experience" name="experience" value="true" <%if(userSettings.game_skill_visibility) {%>checked="checked"<%}%>>
+							<span class="checkmark"></span>
+						</label>
+					</li>
+					<!--<li data-name="birthday_visibility" class="scroll">
+						<p class="settings-label">Show Comment on Profile</p>
+						<label class="checkbox-container" for="comment">
+							<input type="checkbox" id="comment" name="comment" value="true" <%if(userSettings.profile_comment_visibility) {%>checked="checked"<%}%>>
+							<span class="checkmark"></span>
+						</label>
+					</li>-->
+					<input id="submit" type="submit" class="post-button fixed-bottom-button" value="Save">
+				</ul>
+			</div>
+		</form>
     </div>
 </div>
 </body>

--- a/apps/juxtaposition-ui/src/webfiles/ctr/user_page.ejs
+++ b/apps/juxtaposition-ui/src/webfiles/ctr/user_page.ejs
@@ -4,7 +4,12 @@
 <%- include('partials/head', { title: pnid.mii.name }); %>
 <body>
 <div id="body">
-    <header id="header" class="buttons">
+	<header id="header" class="buttons"
+		data-toolbar-config
+		data-toolbar-mode="0"
+		<%if(pnid.pid === pid) {%>
+		data-toolbar-active-button="5"
+		<%}%>>
         <h1 id="page-title" class="community">
             <span>
                 <span class="icon-container">


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves N/A

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

This introduces the user settings page on the 3DS. The larger part of this change includes a new api for configuring the toolbar on a page-by-page basis. The following data tags can be added to a given page, and the toolbar will be updated as appropriate:

| Tag | Action |
| --- | ------ |
|`data-toolbar-config`| This flag is used to identify the element with the rest of the config options|
|`data-toolbar-mode`| Int passed into the `cave.toolbar_setMode()` function |
|`data-toolbar-message`| String passed into the `cave.toolbar_setWideButtonMessage()` function |
|`data-toolbar-onclick`| Executes the function name passed into it when the wide button is clicked. Function name must be declared on the `window` object |
|`data-toolbar-onback`| Same as above, but for the back button |
|`data-toolbar-active-button`| Int passed into the `cave.toolbar_setActiveButton()` function |
|`data-toolbar-bgm`| Name of the BGM track to play when page is loaded |
|`data-toolbar-exit-bgm` | Name of the BGM track to play when the page is exited |
|`data-toolbar-sound` | Name of the sound effect to play when page is loaded |

I've tested this on my N3DS XL and things appear to be fine. If we want to tweak this api at all I'm open to suggestions. I attempted to make this fairly generic so it could be used elsewhere.

Also, since I'm not currently in a spot to overhaul all of the user pages to tsx I'm still using ejs for this. No new ones were added, so I think that's okay for now but I'd like to take a stab at the user pages here in the near future.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.