### PR TITLE
Fix punctuation errors in notifications

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/admin.js
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/admin.js
@@ -282,7 +282,7 @@ adminRouter.delete('/:reportID', async function (req, res) {
 		pid: post.pid,
 		type: 'notice',
 		text: `Your ${postType} "${post.id}" has been removed` +
-			(reason ? ` for the following reason: "${reason}". ` : '.') +
+			(reason ? ` for the following reason: "${reason}". ` : '. ') +
 			`Click this message to view the Juxtaposition Code of Conduct. ` +
 			`If you have any questions, please contact the moderators on the Pretendo Network Forum (forum.pretendo.network).`,
 		image: '/images/bandwidthalert.png',


### PR DESCRIPTION
There were two small punctuation errors introduced in a recent commit (https://github.com/PretendoNetwork/juxtaposition/commit/08043be305421390f3f3a9ec56e26dc0762e1a94) and this PR aims to resolve that.

The "Limited from Posting" notification was missing a space between sentences.

The post removal notification was missing a sentence end period and its space for the next sentence as well.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.