### PR TITLE
fix(ui): increase reply post limit

### DIFF
--- a/apps/juxtaposition-ui/src/api/post.ts
+++ b/apps/juxtaposition-ui/src/api/post.ts
@@ -89,11 +89,12 @@ export async function getPostsByEmpathy(tokens: UserTokens, empathy_by: number, 
 	return posts;
 }
 
-export async function getPostsByParentId(tokens: UserTokens, parent_id: string, offset: number): Promise<PageDto<PostDto> | null> {
+export async function getPostsByParentId(tokens: UserTokens, parent_id: string, offset: number, limit: number): Promise<PageDto<PostDto> | null> {
 	const posts = await apiFetchUser<PageDto<PostDto>>(tokens, `/api/v1/posts`, {
 		query: {
 			parent_id: parent_id,
 			offset,
+			limit,
 			include_replies: true
 		}
 	});

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -169,7 +169,8 @@ postsRouter.get('/:post_id', async function (req, res) {
 		return res.redirect('/404');
 	}
 
-	const replies = (await getPostsByParentId(maybeTokens, post.id, 0))?.items ?? [];
+	// increase limit for post replies since there's no pagination yet
+	const replies = (await getPostsByParentId(maybeTokens, post.id, 0, 500))?.items ?? [];
 	const postPNID = await getUserAccountData(post.pid);
 	const canPost = hasAuth() && (
 		(community.permissions.open && community.type < 2) ||

--- a/apps/miiverse-api/src/services/internal/routes/posts.ts
+++ b/apps/miiverse-api/src/services/internal/routes/posts.ts
@@ -22,7 +22,8 @@ postsRouter.get('/posts', guards.guest, handle(async ({ req, res }) => {
 		empathy_by: z.coerce.number().optional(),
 		parent_id: postIdSchema.optional(),
 		include_replies: z.stringbool().default(false)
-	}).and(pageSchema()).parse(req.query);
+	// Increased page limit for replies
+	}).and(pageSchema(500)).parse(req.query);
 
 	if (query.parent_id && !query.include_replies) {
 		throw new errors.badRequest('Please set include_replies=true to get replies to a parent');


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

In #127, gRPC was introduced which enforced regular offset/limit semantics on feeds. Unfortunately it was missed that the replies to a post are exempt from the post limit (since there's no pagination on that feed). Oops!

Increase the limit to 500 as a quick fix, we can look at real pagination later on

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.