### PR TITLE
fix for reports without reason

### DIFF
--- a/apps/juxtaposition-ui/src/models/report.ts
+++ b/apps/juxtaposition-ui/src/models/report.ts
@@ -40,7 +40,7 @@ export const ReportSchema = new Schema<IReport, ReportModel, IReportMethods>({
 	},
 	message: {
 		type: String,
-		required: true
+		default: ''
 	},
 	created_at: {
 		type: Date,


### PR DESCRIPTION
changes:
- fixed reports without reason failing, `required: true` doesnt allow empty strings