### PR TITLE
Improve speed of community page view

### DIFF
--- a/apps/juxtaposition-ui/src/models/post.js
+++ b/apps/juxtaposition-ui/src/models/post.js
@@ -102,6 +102,13 @@ PostSchema.index({
 	removed: 1
 });
 
+// Index for post count on community page
+PostSchema.index({
+	community_id: 1,
+	removed: 1,
+	parent: 1
+});
+
 PostSchema.methods.upReply = async function () {
 	const replyCount = this.get('reply_count');
 	if (replyCount + 1 < 0) {


### PR DESCRIPTION
changes:
- Added index for community page post count, it was slowing down the entire page load on big communities

The dev environment already has this index. Without it, community page loads became very slow.