### PR TITLE
fix: inconsistent gendering in setup/rules_text/seventh

### DIFF
--- a/apps/juxtaposition-ui/src/translations/en.json
+++ b/apps/juxtaposition-ui/src/translations/en.json
@@ -98,7 +98,7 @@
       "fourth": "Be Nice to One Another",
       "fifth": "In order to keep Juxt a fun place for everyone, we ask that you be considerate to other users. Help us keep Juxt an enjoyable experience by not posting anything inappropriate or offensive.",
       "sixth": "Do Not Post Personal Information—Yours or Others’",
-      "seventh": "Remember, knowing someone in Juxt isn’t the same as knowing them in real life. Never share your e-mail address, home address, work or school name, or other personally identifying information with anyone on Juxt, and never share anyone else's information either. Additionally, if someone you meet in Juxt invites you to meet him or her in the real world, do not accept. Juxt is an online community and should not be used to arrange real-world meet-ups.",
+      "seventh": "Remember, knowing someone in Juxt isn’t the same as knowing them in real life. Never share your e-mail address, home address, work or school name, or other personally identifying information with anyone on Juxt, and never share anyone else's information either. Additionally, if someone you meet in Juxt invites you to meet them in the real world, do not accept. Juxt is an online community and should not be used to arrange real-world meet-ups.",
       "eighth": "Don’t Post Spoilers",
       "ninth": "Some people come to Juxt looking for tips and tricks for games, but others want to discover a game's secrets all on their own. Posts that reveal secrets of a game or its story are called \"spoilers.\" If you're posting something about a game that might be a spoiler, be sure to check the Spoilers box before sending your post. This way, people who don't want to be spoiled won't see your post.",
       "tenth": "Code of Conduct Violations",


### PR DESCRIPTION
The string already names "knowing someone on Juxt isn't the same as knowing **them** in real life", so this commit replaces "him or her" in reference to "someone" with "them" in a later part of this string.

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #354

### Changes:

Replaces "him or her" with "them" in English translations for the "setup" phase (setup/rules_text/seventh), making it consistent with the prior usage of "them" within the same string.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.