### PR TITLE
fix: block replies to removed posts

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -341,6 +341,10 @@ async function newPost(req: Request, res: Response): Promise<void> {
 			return;
 		} else {
 			community = await database.getCommunityByID(parentPost.community_id);
+			if (parentPost.removed) {
+				res.sendStatus(400);
+				return;
+			}
 		}
 	}
 	if (params.post_id && (body.body === '' && body.painting === '' && body.screenshot === '')) {

--- a/apps/miiverse-api/src/services/api/routes/posts.ts
+++ b/apps/miiverse-api/src/services/api/routes/posts.ts
@@ -291,6 +291,10 @@ async function newPost(request: express.Request, response: express.Response): Pr
 					olive_community_id: parentPost.community_id
 				});
 			}
+			if (parentPost.removed) {
+				request.log.warn('Request wants to reply to parent post, but parent post has been removed');
+				return badRequest(response, ApiErrorCode.BAD_PARAMS);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #39 

### Changes:

This PR fixes long-standing issue #39, which allows for users with access level 2 or higher to reply to deleted posts.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.