### PR TITLE
fix(ui): mark User Page nav link as selected when viewing own profile

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/userPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/userPageView.tsx
@@ -88,7 +88,7 @@ export function PortalUserPageView(props: UserPageViewProps): ReactNode {
 
 	return (
 		<PortalRoot title={pnidName}>
-			<PortalNavBar selection={-1} />
+			<PortalNavBar selection={isSelf ? 0 : -1} />
 			<PortalPageBody>
 				<header id="header">
 					{isSelf ? <a id="header-communities-button" className="user-page" href="/users/me/settings" data-pjax="#body">Settings</a> : null}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
@@ -142,7 +142,7 @@ export function WebUserPageView(props: UserPageViewProps): ReactNode {
 	return (
 		<WebRoot head={head}>
 			<h2 id="title" className="page-header"><T k="global.user_page" /></h2>
-			<WebNavBar selection={-1} />
+			<WebNavBar selection={isSelf ? 0 : -1} />
 			<div id="toast"></div>
 			<WebWrapper className="community-page-post-box">
 				<div className="community-top">


### PR DESCRIPTION
## Summary

Fixes #214

When navigating to `/users/me`, the **User Page** link in the sidebar navigation did not receive the `selected` CSS class, so it appeared visually unselected even though the user was on their own profile.

## Root Cause

Both the portal and web `UserPageView` components were passing `selection={-1}` to the navbar, which means no nav item gets highlighted. The user page nav item is index `0`.

## Fix

Use `isSelf` (already computed in both views to determine whether the viewer is looking at their own profile) to conditionally set the selection:

```tsx
// Before
<PortalNavBar selection={-1} />

// After  
<PortalNavBar selection={isSelf ? 0 : -1} />
```

This way:
- Viewing `/users/me` or your own profile: User Page nav item shows `selected`
- Viewing another users profile: no nav item is highlighted (unchanged behavior)

- [x] I have read and agreed to the Code of Conduct
- [x] I have read and complied with the contributing guidelines
- [x] What I am implementing was an approved issue