### PR TITLE
Fixed spoiler whitespacing bug

### DIFF
--- a/apps/juxtaposition-ui/webfiles/ctr/js/juxt.js
+++ b/apps/juxtaposition-ui/webfiles/ctr/js/juxt.js
@@ -76,11 +76,11 @@ function initSpoilers() {
 	for (var i = 0; i < els.length; i++) {
 		els[i].addEventListener('click', function (e) {
 			var el = e.currentTarget;
-			var target = document.getElementById('post-' + el.getAttribute('data-post-id'));
-			target.classList.remove(
-				'spoiler'
-			);
-			el.outerHTML = '';
+			var spoilerWrapper = document.getElementById('spoiler-' + el.getAttribute('data-post-id'));
+			var postEl = document.getElementById('post-' + el.getAttribute('data-post-id'));
+
+			postEl.classList.remove('spoiler');
+			spoilerWrapper.outerHTML = '';
 			cave.snd_playSe('SE_OLV_OK');
 		});
 	}


### PR DESCRIPTION
Changes:
- Fixed spoiler whitespacing bug, restored original functionality that’s currently on prod

Caused by not removing the right element for the spoilers. related #425 

Changes have been tested locally