### PR TITLE
fix: Arrow Dropdown in User Moderation Page

### DIFF
--- a/apps/juxtaposition-ui/webfiles/web/css/web.css
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.css
@@ -1295,7 +1295,7 @@ summary::before {
   margin-left: -1em;
 }
 
-details[open] summary::before {
+details[open]>summary::before {
   content: "▼";
 }
 


### PR DESCRIPTION
This PR fixes #376 

It was a CSS error, changed descendant combinator to child combinator.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.