### PR TITLE
fix: prevent posts of deleted/banned users from being viewed

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
@@ -247,14 +247,20 @@ export function WebUserPageView(props: UserPageViewProps): ReactNode {
 							)
 						: null}
 				</div>
-				<div className="buttons tabs">
-					<a id="tab-header-post" className={props.selectedTab === 0 ? 'selected' : ''} href={props.baseLink}><T k="user_page.posts" /></a>
-					<a id="tab-header-friends" className={props.selectedTab === 1 ? 'selected' : ''} href={props.baseLink + 'friends'}><T k="user_page.friends" /></a>
-					<a id="tab-header-following" className={props.selectedTab === 2 ? 'selected' : ''} href={props.baseLink + 'following'}><T k="user_page.following" /></a>
-					<a id="tab-header-followers" className={props.selectedTab === 3 ? 'selected' : ''} href={props.baseLink + 'followers'}><T k="user_page.followers" /></a>
-					<a id="tab-header-yeahs" className={props.selectedTab === 4 ? 'selected' : ''} href={props.baseLink + 'yeahs'}><T k="global.yeahs" /></a>
-				</div>
-				{props.children}
+				{ isUserDataViewable
+					? (
+							<>
+								<div className="buttons tabs">
+									<a id="tab-header-post" className={props.selectedTab === 0 ? 'selected' : ''} href={props.baseLink}><T k="user_page.posts" /></a>
+									<a id="tab-header-friends" className={props.selectedTab === 1 ? 'selected' : ''} href={props.baseLink + 'friends'}><T k="user_page.friends" /></a>
+									<a id="tab-header-following" className={props.selectedTab === 2 ? 'selected' : ''} href={props.baseLink + 'following'}><T k="user_page.following" /></a>
+									<a id="tab-header-followers" className={props.selectedTab === 3 ? 'selected' : ''} href={props.baseLink + 'followers'}><T k="user_page.followers" /></a>
+									<a id="tab-header-yeahs" className={props.selectedTab === 4 ? 'selected' : ''} href={props.baseLink + 'yeahs'}><T k="global.yeahs" /></a>
+								</div>
+								{props.children}
+							</>
+						)
+					: null}
 			</WebWrapper>
 			<WebReportModalView />
 		</WebRoot>


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #461

### Changes:

This fix prevents posts of deleted/banned users from being viewed. These posts qualify as user data, so if a user is banned they should be hidden.

As mentioned in #461 (links go to private channels), [this is known to be a bug](https://discord.com/channels/408718485913468928/881694875391774770/1476671640187441203), and we agree something should be changed, but [we do not have agreement on how to fix it](https://discord.com/channels/408718485913468928/1307850413999001692/1483321841811460097). Currently, the angle of this PR is to simply make profiles behave as the original design intended to prevent stalking from bad actors, with the idea that we can adjust our design/intention at a later point. This angle (and therefore what this PR aims to solve) may change as discussion continues.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.