### PR TITLE
Add missing checks to some `newPostSchema` fields

### DIFF
--- a/apps/miiverse-api/src/services/api/routes/posts.ts
+++ b/apps/miiverse-api/src/services/api/routes/posts.ts
@@ -33,7 +33,7 @@ const APP_DATA_MAX_SIZE = 0x400; // * Real name is `nn::olv::APP_DATA_MAX_SIZE`
 const newPostSchema = z.object({
 	community_id: z.string().optional(),
 	// TODO - This will trigger the generic `ApiErrorCode.BAD_PARAMS` error when the size check fails, is there a specific error code for this case?
-	app_data: z.string().base64().refine((appData: string) => Buffer.from(appData, 'base64').length < APP_DATA_MAX_SIZE).optional(),
+	app_data: z.string().base64().refine((appData: string) => Buffer.from(appData, 'base64').length <= APP_DATA_MAX_SIZE).optional(),
 	painting: z.string().base64().optional(),
 	screenshot: z.string().base64().optional(),
 	body: z.string().optional(),


### PR DESCRIPTION
Resolves #XXX

### Changes:

- Adds `.base64()` Zod checks to `app_data`, `painting`, and `screenshot`
- Adds a length check to `app_data`

The appdata is capped at 1kb officially but this wasn't being enforced. Only realized this while looking at something in Shovel Knight related to Miiverse, was this known before? Or does it need to be documented still? I got the real name from some debug logs in Shovel Knight.

Originally I was only adding the 1kb size check, but then I noticed that the `painting` and `screenshot` fields also lacked the base64 check at the Zod level so I tacked those on while I was here. This does, however, make these 3 `replace` calls redundant:

```ts
const painting = bodyCheck.data.painting?.replace(/\0/g, '').trim() || '';
const screenshot = bodyCheck.data.screenshot?.replace(/\0/g, '').trim() || '';
const appData = bodyCheck.data.app_data?.replace(/[^A-Za-z0-9+/=\s]/g, '').trim() || '';
```

Since Zod will throw an error in cases where the base64 is invalid. These 3 lines look smelly to me anyway, have we seen official clients send badly formatted data before? I can't remember if these 3 lines are required or just defensive. If they are required and the official client does send that badly formatted data, then the `.base()` checks will need to be removed from the Zod level otherwise """good""" data will never reach this stage. But I find it odd that the official client would send bad data like this? Pinging @ashquarky and @CaramelKat for input there.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes. (I tested the changes in a control script, not using an actual client, since the changes were so simple. Hence the possibility of the `.base()` needing to be removed. But the length check matches what real clients do so it should be fine here too)