### PR TITLE
Update Duplicate check to only check in the last 5 minutes

### DIFF
--- a/apps/juxtaposition-ui/src/database.js
+++ b/apps/juxtaposition-ui/src/database.js
@@ -114,12 +114,16 @@ async function getPostReplies(postID, number) {
 	}).limit(number);
 }
 
-async function getDuplicatePosts(pid, post) {
+async function getDuplicatePosts(pid, post, olderThanMs) {
 	verifyConnected();
 	return POST.findOne({
 		pid: pid,
 		body: post.body,
 		screenshot: post.screenshot,
+		painting: post.painting,
+		created_at: {
+			$gte: new Date(Date.now() - olderThanMs)
+		},
 		parent: null,
 		removed: false
 	});

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -488,7 +488,8 @@ async function newPost(req: Request, res: Response): Promise<void> {
 		verified: res.locals.moderator,
 		parent: parentPost ? parentPost.id : null
 	};
-	const duplicatePost = await database.getDuplicatePosts(auth().pid, document);
+	const maxDuplicatePostAgeMs = 5 * 60 * 1000;
+	const duplicatePost = await database.getDuplicatePosts(auth().pid, document, maxDuplicatePostAgeMs);
 	if (duplicatePost && params.post_id) {
 		return res.redirect('/posts/' + params.post_id.toString());
 	}

--- a/apps/miiverse-api/src/database.ts
+++ b/apps/miiverse-api/src/database.ts
@@ -98,13 +98,17 @@ export async function getPostReplies(postID: string, limit: number): Promise<Hyd
 	}).limit(limit);
 }
 
-export async function getDuplicatePosts(pid: number, post: IPostInput): Promise<HydratedPostDocument | null> {
+export async function getDuplicatePosts(pid: number, post: IPostInput, olderThanMs: number): Promise<HydratedPostDocument | null> {
 	verifyConnected();
 
 	return Post.findOne({
 		pid: pid,
 		body: post.body,
 		screenshot: post.screenshot,
+		painting: post.painting,
+		created_at: {
+			$gte: new Date(Date.now() - olderThanMs)
+		},
 		parent: null,
 		removed: false
 	});

--- a/apps/miiverse-api/src/services/api/routes/posts.ts
+++ b/apps/miiverse-api/src/services/api/routes/posts.ts
@@ -393,7 +393,8 @@ async function newPost(request: express.Request, response: express.Response): Pr
 		removed: false
 	};
 
-	const duplicatePost = await getDuplicatePosts(request.pid, document);
+	const maxDuplicatePostAgeMs = 5 * 60 * 1000;
+	const duplicatePost = await getDuplicatePosts(request.pid, document, maxDuplicatePostAgeMs);
 
 	if (duplicatePost) {
 		return badRequest(response, ApiErrorCode.NOT_ALLOWED_SPAM, 403);


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Related to #99 

### Changes: Removes the Duplicate painting check off the API and UI. 

Remaking this. 
This shouldn't need to be the simplest fix ever for this, but right now this is all i can do without messing stuff up.

This just removes the Painting spam check off the API and UI. 
This has been a issue for a while, and wanted to see if i could fix it myself. after a failed attempt on a pull request, i realized i could just... remove the check.

This should fix 115-5024 on Drawings and permanently locking you out of them on in-game posts. this is a temp solution for now until we revamp or remove all of the checks.


I don't have a environment to locally test this. so for now. the testing mark remains unchecked.


- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.