### PR TITLE
fix: "Delete" button now says "Delete"

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/post.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/post.tsx
@@ -143,7 +143,7 @@ export function WebPostView(props: PostViewProps): ReactNode {
 									<li role="menuitem" data-action="delete" data-moderator={isModerator}>
 										<WebUIIcon name="bin" />
 										{' '}
-										{isModerator ? <T k="moderation.silently_delete_post" /> : <T k="post.report_post" />}
+										{isModerator ? <T k="moderation.silently_delete_post" /> : <T k="post.delete_post" />}
 									</li>
 								)
 							: null}


### PR DESCRIPTION
Fixes #470 

In the HTML, it was calling the "report_post" key instead of the "delete_post" key.
- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.