### PR TITLE
fix(ui): fix link stacking on community icons by making links optional

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/components/ui/CtrCommunityIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/components/ui/CtrCommunityIcon.tsx
@@ -7,11 +7,9 @@ export function CtrCommunityIcon(props: CommunityIconProps): ReactNode {
 	const url = useUrl();
 	const imageId = props.community.parent ? props.community.parent : props.community.olive_community_id;
 	const iconUrl = props.community.icon_paths ? url.cdn(props.community.icon_paths[props.size]) : url.cdn(`/icons/${imageId}/${props.size}.png`);
-	const href = `/communities/${props.community.olive_community_id}`;
 
 	return (
 		<CtrIcon
-			href={href}
 			src={iconUrl}
 			type="icon"
 			className={props.className}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/components/ui/CtrIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/components/ui/CtrIcon.tsx
@@ -4,9 +4,25 @@ import type { IconProps } from '@/services/juxt-web/views/web/components/ui/WebI
 
 export function CtrIcon(props: IconProps): ReactNode {
 	const type = props.type ?? 'icon';
-	return (
-		<a href={props.href} className={cx(`${type}-container`, props.className)} data-pjax="#body">
-			<img src={props.src} className={type} />
-		</a>
-	);
+
+	const icon = <img src={props.src} className={type} />;
+	if (props.href) {
+		return (
+			<a
+				href={props.href}
+				className={cx(`${type}-container`, props.className)}
+				data-pjax="#body"
+			>
+				{icon}
+			</a>
+		);
+	} else {
+		return (
+			<div
+				className={cx(`${type}-container`, props.className)}
+			>
+				{icon}
+			</div>
+		);
+	}
 }

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/components/ui/PortalCommunityIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/components/ui/PortalCommunityIcon.tsx
@@ -7,11 +7,9 @@ export function PortalCommunityIcon(props: CommunityIconProps): ReactNode {
 	const url = useUrl();
 	const imageId = props.community.parent ? props.community.parent : props.community.olive_community_id;
 	const iconUrl = props.community.icon_paths ? url.cdn(props.community.icon_paths[props.size]) : url.cdn(`/icons/${imageId}/${props.size}.png`);
-	const href = `/communities/${props.community.olive_community_id}`;
 
 	return (
 		<PortalIcon
-			href={href}
 			src={iconUrl}
 			type="icon"
 			className={props.className}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/components/ui/PortalIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/components/ui/PortalIcon.tsx
@@ -4,9 +4,25 @@ import type { IconProps } from '@/services/juxt-web/views/web/components/ui/WebI
 
 export function PortalIcon(props: IconProps): ReactNode {
 	const type = props.type ?? 'icon';
-	return (
-		<a href={props.href} className={cx(`${type}-container`, props.className)} data-pjax="#body">
-			<img src={props.src} className={type} />
-		</a>
-	);
+
+	const icon = <img src={props.src} className={type} />;
+	if (props.href) {
+		return (
+			<a
+				href={props.href}
+				className={cx(`${type}-container`, props.className)}
+				data-pjax="#body"
+			>
+				{icon}
+			</a>
+		);
+	} else {
+		return (
+			<div
+				className={cx(`${type}-container`, props.className)}
+			>
+				{icon}
+			</div>
+		);
+	}
 }

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebCommunityIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebCommunityIcon.tsx
@@ -14,11 +14,9 @@ export function WebCommunityIcon(props: CommunityIconProps): ReactNode {
 	const url = useUrl();
 	const imageId = props.community.parent ? props.community.parent : props.community.olive_community_id;
 	const iconUrl = props.community.icon_paths ? url.cdn(props.community.icon_paths[props.size]) : url.cdn(`/icons/${imageId}/${props.size}.png`);
-	const href = `/communities/${props.community.olive_community_id}`;
 
 	return (
 		<WebIcon
-			href={href}
 			src={iconUrl}
 			type="icon"
 			className={props.className}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebIcon.tsx
@@ -11,9 +11,24 @@ export type IconProps = {
 
 export function WebIcon(props: IconProps): ReactNode {
 	const type = props.type ?? 'icon';
-	return (
-		<a href={props.href} className={cx(`${type}-container`, props.className)}>
-			<img src={props.src} className={type} />
-		</a>
-	);
+
+	const icon = <img src={props.src} className={type} />;
+	if (props.href) {
+		return (
+			<a
+				href={props.href}
+				className={cx(`${type}-container`, props.className)}
+			>
+				{icon}
+			</a>
+		);
+	} else {
+		return (
+			<div
+				className={cx(`${type}-container`, props.className)}
+			>
+				{icon}
+			</div>
+		);
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2942,7 +2942,6 @@
             "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.11.0.tgz",
             "integrity": "sha512-GHoprlNQD51Xq2Ztd94HHV94MdFZQ3CVrpA04Fz8MVoHM0B7SlbmPEVIjwTbcv58z8QyjnrOuikS0rWF03k5dQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cluster-key-slot": "1.1.2"
             },
@@ -4119,7 +4118,6 @@
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
             "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
-            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -4280,7 +4278,6 @@
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -4424,7 +4421,6 @@
             "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.56.1",
                 "@typescript-eslint/types": "8.56.1",
@@ -4915,7 +4911,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5473,7 +5468,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -6562,7 +6556,6 @@
             "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -6682,7 +6675,6 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -6851,7 +6843,6 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -7222,7 +7213,6 @@
             "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.19.0.tgz",
             "integrity": "sha512-0csaMkGq+vaiZTmSMMGkfdCOabYv192VbytFypcvI0MANrp+4i/7yEkJ0sbAEhycQjntaKGzYfjfXQyVb7BHMA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "cookie": "~0.7.2",
                 "cookie-signature": "~1.0.7",
@@ -8143,7 +8133,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.28.6"
             },
@@ -11283,7 +11272,6 @@
             "version": "15.1.3",
             "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
             "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
-            "peer": true,
             "dependencies": {
                 "@opentelemetry/api": "^1.4.0",
                 "tdigest": "^0.1.1"
@@ -11463,7 +11451,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
             "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11593,7 +11580,6 @@
             "resolved": "https://registry.npmjs.org/redis/-/redis-5.11.0.tgz",
             "integrity": "sha512-YwXjATVDT+AuxcyfOwZn046aml9jMlQPvU1VXIlLDVAExe0u93aTfPYSeRgG4p9Q/Jlkj+LXJ1XEoFV+j2JKcQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@redis/bloom": "5.11.0",
                 "@redis/client": "5.11.0",
@@ -12277,7 +12263,6 @@
             "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ip-address": "^10.0.1",
                 "smart-buffer": "^4.2.0"
@@ -13374,7 +13359,6 @@
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -13503,7 +13487,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "napi-postinstall": "^0.3.0"
             },


### PR DESCRIPTION
After changing how icons work, <a> tags were being nested inside other <a> tags, causing parsing to break. This most notably made the community list only partially clickable.

Fix this by removing the links on icons altogether.

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.