### PR TITLE
fix(ui): redirect out from /communities/0

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/communities.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/communities.tsx
@@ -59,7 +59,7 @@ communitiesRouter.get('/all', async function (req, res) {
 });
 
 communitiesRouter.get('/:communityID', async function (req, res) {
-	const { query, params } = parseReq(req, {
+	const { query, params, auth } = parseReq(req, {
 		query: z.object({
 			title_id: z.string().optional()
 		}),
@@ -70,6 +70,18 @@ communitiesRouter.get('/:communityID', async function (req, res) {
 
 	if (query.title_id) {
 		const community = await database.getCommunityByTitleID(query.title_id);
+		if (!community) {
+			return res.redirect('/404');
+		}
+		return res.redirect(`/titles/${community.olive_community_id}/new`);
+	}
+
+	if (params.communityID == '0') {
+		const tid = auth().paramPackData?.title_id;
+		if (!tid) {
+			return res.redirect('/404');
+		}
+		const community = await database.getCommunityByTitleID(tid);
 		if (!community) {
 			return res.redirect('/404');
 		}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #487

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Adds a path for handling `/communities/0` with the title ID in the param pack. Some games (Team Kirby, BOXBOY) apparently rely on this to find their own community on portal.

Was unable to test since I do not own a game that behaves like this.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.