### PR TITLE
Fixes for datasource move part 1

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -169,7 +169,7 @@ postsRouter.get('/:post_id', async function (req, res) {
 	}
 
 	// increase limit for post replies since there's no pagination yet
-	const replies = (await req.api.posts.list({ parent_id: post.id, include_replies: 'true', limit: 500 }))?.data.items ?? [];
+	const replies = (await req.api.posts.list({ parent_id: post.id, include_replies: 'true', sort: 'oldest', limit: 500 }))?.data.items ?? [];
 	const postPNID = await getUserAccountData(post.pid);
 	const canPost = hasAuth() && userSettings !== null && isPostingAllowed(community, userSettings, post, auth().user);
 

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/common/hooks/useUrl.ts
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/common/hooks/useUrl.ts
@@ -24,7 +24,7 @@ function getCtrHeader(cdnBaseUrl: string, community: Community): CtrHeader {
 	const imageId = community.parentId ? community.parentId : community.olive_community_id;
 	const bannerUrl = buildCdnUrl(cdnBaseUrl, community.ctrHeaderImagePath);
 
-	const legacy = !community.hasLegacyCtrHeader;
+	const legacy = community.hasLegacyCtrHeader;
 
 	return { bannerUrl, imageId, legacy };
 }

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/userPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/userPageView.tsx
@@ -85,7 +85,6 @@ export function PortalUserPageView(props: UserPageViewProps): ReactNode {
 	const isSelf = user.pid === props.user.pid;
 
 	const isRequesterFollowingUser = props.requestUserContent?.followed_users.includes(props.user.pid) ?? false;
-	const isUserFollowingRequester = props.userContent.followed_users.includes(user.pid);
 
 	return (
 		<PortalRoot title={pnidName}>
@@ -107,7 +106,6 @@ export function PortalUserPageView(props: UserPageViewProps): ReactNode {
 							? (
 									<>
 										<a href="#" className={cx('favorite-button favorite-button-mini button', { checked: isRequesterFollowingUser })} evt-click="follow(this)" data-sound="SE_WAVE_CHECKBOX_UNCHECK" data-url="/users/follow" data-community-id={props.user.pid}></a>
-										{ isRequesterFollowingUser && isUserFollowingRequester ? <a href={`/friend_messages/new/${props.user.pid}`} className="message-button favorite-button-mini button" data-sound="SE_WAVE_CHECKBOX_UNCHECK"></a> : null }
 									</>
 								)
 							: null}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
@@ -132,7 +132,6 @@ export function WebUserPageView(props: UserPageViewProps): ReactNode {
 	const isSelf = user.pid === props.user.pid;
 
 	const isRequesterFollowingUser = props.requestUserContent?.followed_users.includes(props.user.pid) ?? false;
-	const isUserFollowingRequester = props.userContent.followed_users.includes(user.pid);
 
 	let head: ReactNode = null;
 	if (isUserDataViewable) {
@@ -180,7 +179,6 @@ export function WebUserPageView(props: UserPageViewProps): ReactNode {
 										>
 											{isRequesterFollowingUser ? <T k="user_page.following_user" /> : <T k="user_page.follow_user" />}
 										</a>
-										{ isRequesterFollowingUser && isUserFollowingRequester ? <a href={`/friend_messages/new/${props.user.pid}`} className="message-button" data-sound="SE_WAVE_CHECKBOX_UNCHECK"></a> : null }
 									</>
 								)
 							: null }

--- a/migrations/3-remove-messages.js
+++ b/migrations/3-remove-messages.js
@@ -1,7 +1,7 @@
 // Messages have been removed from frontend, this script will remove all messages (not posts) from the database
 // ---
 // This script is intended to run in mongosh:
-// $ mongosh mongodb://localhost:27017/mydb 2-correct-screenshot-aspect.js
+// $ mongosh mongodb://localhost:27017/mydb 3-remove-messages.js
 
 print(`Removing messages`);
 const result = db.posts.deleteMany({

--- a/migrations/4-fix-community-types.js
+++ b/migrations/4-fix-community-types.js
@@ -1,0 +1,21 @@
+// Production has some instances of incorrect community types, this corrects them
+// ---
+// This script is intended to run in mongosh:
+// $ mongosh mongodb://localhost:27017/mydb 4-fix-community-types.js
+
+print(`Correcting incorrect subcommunities`);
+
+const result = db.communities.updateMany({
+	type: {
+		$in: [0, 2], // Non-subcommunity types...
+	},
+	parent: {
+		$ne: null, // .. that are subcommunities
+	}
+}, {
+	$set: {
+		type: 3, // Set to private
+	}
+});
+
+print(`Updated ${result.modifiedCount}/${result.matchedCount} documents!`);


### PR DESCRIPTION
Fixes for bugs introduced in #479 

Changes:
- Fixed reply order
- Fixed legacy CTR banners not being displayed properly
- Fixed subcommunities showing up in community lists
  - We have a couple of subcommunities (`parent != null`) that are marked as announcement communities. Added a migration to correct them. Gonna assume it's leftover from an old fixed exploit.
- Bonus fix: removed messages button from userpage, it was missed in #483 

Resolves #486 