### PR TITLE
Add basic automod functionality

### DIFF
--- a/apps/juxtaposition-ui/src/assets/locales/en.json
+++ b/apps/juxtaposition-ui/src/assets/locales/en.json
@@ -99,6 +99,7 @@
     "none": "No Friend Requests"
   },
   "new_post": {
+    "automod_error": "Your post contains text that is not allowed on Juxtaposition. For more information, please visit https://preten.do/juxt-rules",
     "new_post_short": "Post",
     "post_to": "Post to {{user}}",
     "swearing": "Post cannot contain explicit language.",

--- a/apps/juxtaposition-ui/src/models/automodLog.ts
+++ b/apps/juxtaposition-ui/src/models/automodLog.ts
@@ -1,0 +1,41 @@
+import { Schema, model } from 'mongoose';
+import type { HydratedDocument } from 'mongoose';
+
+export const automodAction = ['blocked', 'logged'] as const;
+export type AutomodAction = (typeof automodAction)[number];
+
+export type AutomodLog = {
+	rule_id: string;
+	created_at: Date;
+	action: AutomodAction;
+	post_id: string | null;
+	post_content_body: string | null;
+} & Document;
+
+export type HydratedAutomodLogDocument = HydratedDocument<AutomodLog>;
+
+export const automodLogSchema = new Schema<AutomodLog>({
+	rule_id: {
+		type: String,
+		required: true
+	},
+	created_at: {
+		type: Date,
+		required: true
+	},
+	action: {
+		type: String,
+		enum: automodAction,
+		required: true
+	},
+	post_id: {
+		type: String,
+		required: false
+	},
+	post_content_body: {
+		type: String,
+		required: false
+	}
+});
+
+export const AutomodLog = model('AutomodLog', automodLogSchema);

--- a/apps/juxtaposition-ui/src/models/automodLog.ts
+++ b/apps/juxtaposition-ui/src/models/automodLog.ts
@@ -7,6 +7,7 @@ export type AutomodAction = (typeof automodAction)[number];
 export type AutomodLog = {
 	rule_id: string;
 	created_at: Date;
+	author: number;
 	action: AutomodAction;
 	post_id: string | null;
 	post_content_body: string | null;
@@ -26,6 +27,10 @@ export const automodLogSchema = new Schema<AutomodLog>({
 	action: {
 		type: String,
 		enum: automodAction,
+		required: true
+	},
+	author: {
+		type: Number,
 		required: true
 	},
 	post_id: {

--- a/apps/juxtaposition-ui/src/models/automodRules.ts
+++ b/apps/juxtaposition-ui/src/models/automodRules.ts
@@ -1,0 +1,60 @@
+import { Schema, model } from 'mongoose';
+import type { HydratedDocument } from 'mongoose';
+
+export const automodRuleType = ['keyword'] as const;
+export type AutomodRuleType = (typeof automodRuleType)[number];
+
+export const automodRuleMode = ['block', 'log'] as const;
+export type AutomodRuleMode = (typeof automodRuleMode)[number];
+
+export type AutomodKeywordSettings = {
+	keywords: string[];
+} & Document;
+
+export type AutomodRule = {
+	enabled: boolean;
+	title: string;
+	description: string | null;
+	type: AutomodRuleType;
+	mode: AutomodRuleMode;
+	keyword_settings: {
+		keywords: string[];
+	};
+} & Document;
+
+export type HydratedAutomodRuleDocument = HydratedDocument<AutomodRule>;
+
+export const automodRuleKeywordSettingsSchema = new Schema<AutomodKeywordSettings>({
+	keywords: {
+		type: [String],
+		required: true
+	}
+});
+
+export const automodRuleSchema = new Schema<AutomodRule>({
+	enabled: {
+		type: Boolean,
+		required: true
+	},
+	title: {
+		type: String,
+		required: true
+	},
+	description: String,
+	type: {
+		type: String,
+		enum: automodRuleType,
+		required: true
+	},
+	mode: {
+		type: String,
+		enum: automodRuleMode,
+		required: true
+	},
+	keyword_settings: {
+		type: automodRuleKeywordSettingsSchema,
+		required: false
+	}
+});
+
+export const AutomodRule = model('AutomodRule', automodRuleSchema);

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/admin.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/admin.tsx
@@ -27,7 +27,7 @@ const upload = multer({ storage: storage });
 export const adminRouter = express.Router();
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Too difficult to type
-const onOffSchema = () => z.enum(['on', 'off']).default('off').transform(v => v === 'on' ? 1 : 0);
+export const onOffSchema = () => z.enum(['on', 'off']).default('off').transform(v => v === 'on' ? 1 : 0);
 
 adminRouter.get('/posts', async function (req, res) {
 	if (!res.locals.moderator) {

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
@@ -2,6 +2,11 @@ import express from 'express';
 import { z } from 'zod';
 import { parseReq } from '@/services/juxt-web/routes/routeUtils';
 import { WebAutomodLogListView } from '@/services/juxt-web/views/web/admin/automodLogListView';
+import { automodRuleMode, automodRuleType } from '@/models/automodRules';
+import { WebAutomodRuleListView } from '@/services/juxt-web/views/web/admin/automodRuleListView';
+import { WebAutomodRuleCreateView } from '@/services/juxt-web/views/web/admin/automodRuleCreateView';
+import { onOffSchema } from '@/services/juxt-web/routes/admin/admin';
+import type { AutomodRuleListViewProps } from '@/services/juxt-web/views/web/admin/automodRuleListView';
 import type { AutomodLogListViewProps } from '@/services/juxt-web/views/web/admin/automodLogListView';
 
 export const adminAutomodRouter = express.Router();
@@ -18,7 +23,7 @@ adminAutomodRouter.get('/automod', async function (req, res) {
 		})
 	});
 
-	const limit = 50;
+	const limit = 100;
 	const offset = query.page * limit;
 	const { data: logPage } = await req.api.admin.automodLogs.list({
 		action: query.action,
@@ -37,4 +42,113 @@ adminAutomodRouter.get('/automod', async function (req, res) {
 	return res.jsxForDirectory({
 		web: <WebAutomodLogListView {...props} />
 	});
+});
+
+adminAutomodRouter.get('/automod/rules', async function (req, res) {
+	if (!res.locals.moderator) {
+		return res.redirect('/titles/show');
+	}
+
+	const { query } = parseReq(req, {
+		query: z.object({
+			page: z.coerce.number().default(0)
+		})
+	});
+
+	const limit = 50;
+	const offset = query.page * limit;
+	const { data: rulePage } = await req.api.admin.automodRules.list({
+		offset,
+		limit
+	});
+	const hasNextPage = offset + limit < rulePage.total;
+
+	const props: AutomodRuleListViewProps = {
+		items: rulePage.items,
+		total: rulePage.total,
+		page: query.page,
+		hasNextPage
+	};
+
+	return res.jsxForDirectory({
+		web: <WebAutomodRuleListView {...props} />
+	});
+});
+
+adminAutomodRouter.get('/automod/rules/create', async function (req, res) {
+	if (!res.locals.moderator) {
+		return res.redirect('/titles/show');
+	}
+
+	return res.jsxForDirectory({
+		web: <WebAutomodRuleCreateView />
+	});
+});
+
+adminAutomodRouter.post('/automod/rules/create', async function (req, res) {
+	const { body } = parseReq(req, {
+		body: z.object({
+			title: z.string().min(1),
+			type: z.enum(automodRuleType),
+			mode: z.enum(automodRuleMode)
+		})
+	});
+
+	await req.api.admin.automodRules.create({
+		mode: body.mode,
+		type: body.type,
+		title: body.title
+	});
+
+	res.redirect('/admin/automod/rules');
+});
+
+adminAutomodRouter.post('/automod/rules/:id/update', async function (req, res) {
+	const { body, params } = parseReq(req, {
+		params: z.object({
+			id: z.string()
+		}),
+		body: z.object({
+			title: z.string().min(1),
+			description: z.string(),
+			type: z.enum(automodRuleType),
+			mode: z.enum(automodRuleMode),
+			enabled: onOffSchema(),
+			keywordSettingsKeywords: z.string().default('')
+		})
+	});
+
+	const keywords = body.keywordSettingsKeywords.split('\n').map(v => v.trim()).filter(v => v.length > 0);
+
+	await req.api.admin.automodRules.update({
+		id: params.id,
+		mode: body.mode,
+		type: body.type,
+		title: body.title,
+		description: body.description,
+		enabled: !!body.enabled,
+		settings: {
+			keyword: body.type === 'keyword'
+				? {
+						keywords: keywords
+					}
+				: undefined
+		}
+	});
+
+	res.redirect('/admin/automod/rules');
+});
+
+adminAutomodRouter.post('/automod/rules/:id/delete', async function (req, res) {
+	const { params } = parseReq(req, {
+		params: z.object({
+			id: z.string()
+		})
+	});
+
+	await req.api.admin.automodRules.delete({
+		id: params.id
+	});
+
+	res.redirect('/admin/automod/rules');
 });

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
@@ -1,0 +1,40 @@
+import express from 'express';
+import { z } from 'zod';
+import { parseReq } from '@/services/juxt-web/routes/routeUtils';
+import { WebAutomodLogListView } from '@/services/juxt-web/views/web/admin/automodLogListView';
+import type { AutomodLogListViewProps } from '@/services/juxt-web/views/web/admin/automodLogListView';
+
+export const adminAutomodRouter = express.Router();
+
+adminAutomodRouter.get('/automod', async function (req, res) {
+	if (!res.locals.moderator) {
+		return res.redirect('/titles/show');
+	}
+
+	const { query } = parseReq(req, {
+		query: z.object({
+			action: z.enum(['blocked', 'logged']).optional(),
+			page: z.coerce.number()
+		})
+	});
+
+	const limit = 50;
+	const offset = query.page * limit;
+	const { data: logPage } = await req.api.admin.automodLogs.list({
+		action: query.action,
+		offset,
+		limit
+	});
+	const hasNextPage = offset + limit > logPage.total;
+
+	const props: AutomodLogListViewProps = {
+		items: logPage.items,
+		total: logPage.total,
+		page: query.page,
+		hasNextPage
+	};
+
+	return res.jsxForDirectory({
+		web: <WebAutomodLogListView {...props} />
+	});
+});

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
@@ -67,7 +67,8 @@ adminAutomodRouter.get('/automod/rules', async function (req, res) {
 		items: rulePage.items,
 		total: rulePage.total,
 		page: query.page,
-		hasNextPage
+		hasNextPage,
+		canEdit: res.locals.developer
 	};
 
 	return res.jsxForDirectory({
@@ -76,7 +77,7 @@ adminAutomodRouter.get('/automod/rules', async function (req, res) {
 });
 
 adminAutomodRouter.get('/automod/rules/create', async function (req, res) {
-	if (!res.locals.moderator) {
+	if (!res.locals.developer) {
 		return res.redirect('/titles/show');
 	}
 

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/adminAutomod.tsx
@@ -14,7 +14,7 @@ adminAutomodRouter.get('/automod', async function (req, res) {
 	const { query } = parseReq(req, {
 		query: z.object({
 			action: z.enum(['blocked', 'logged']).optional(),
-			page: z.coerce.number()
+			page: z.coerce.number().default(0)
 		})
 	});
 
@@ -25,7 +25,7 @@ adminAutomodRouter.get('/automod', async function (req, res) {
 		offset,
 		limit
 	});
-	const hasNextPage = offset + limit > logPage.total;
+	const hasNextPage = offset + limit < logPage.total;
 
 	const props: AutomodLogListViewProps = {
 		items: logPage.items,

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/index.ts
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/index.ts
@@ -1,0 +1,8 @@
+import { Router } from 'express';
+import { adminRouter } from '@/services/juxt-web/routes/admin/admin';
+import { adminAutomodRouter } from '@/services/juxt-web/routes/admin/adminAutomod';
+
+export const baseAdminRouter = Router();
+
+baseAdminRouter.use(adminRouter);
+baseAdminRouter.use(adminAutomodRouter);

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/communities.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/communities.tsx
@@ -25,6 +25,7 @@ import type { CommunityViewProps } from '@/services/juxt-web/views/web/community
 import type { SubCommunityViewProps } from '@/services/juxt-web/views/portal/subCommunityView';
 import type { CommunityListViewProps, CommunityOverviewViewProps } from '@/services/juxt-web/views/web/communityListView';
 import type { Post } from '@/api/generated';
+import type { NewPostViewProps } from '@/services/juxt-web/views/web/newPostView';
 
 const upload = multer({ dest: 'uploads/' });
 export const communitiesRouter = express.Router();
@@ -129,9 +130,12 @@ communitiesRouter.get('/:communityID/related', async function (req, res) {
 });
 
 communitiesRouter.get('/:communityID/create', async function (req, res) {
-	const { params, auth } = parseReq(req, {
+	const { params, query, auth } = parseReq(req, {
 		params: z.object({
 			communityID: z.string()
+		}),
+		query: z.object({
+			'error-text': z.string().optional()
 		})
 	});
 
@@ -142,13 +146,14 @@ communitiesRouter.get('/:communityID/create', async function (req, res) {
 
 	const shotMode = getShotMode(community, auth().paramPackData);
 
-	const props = {
+	const props: NewPostViewProps = {
 		id: community.olive_community_id,
 		name: community.name,
 		url: `/posts/new`,
 		show: 'post',
 		shotMode,
-		community
+		community,
+		errorText: query['error-text']
 	};
 	res.jsxForDirectory({
 		ctr: <CtrNewPostPage {...props} />,

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -10,7 +10,7 @@ import { logger } from '@/logger';
 import { POST } from '@/models/post';
 import { REPORT } from '@/models/report';
 import { redisRemove } from '@/redisCache';
-import { createLogEntry, getInvalidPostRegex, getUserAccountData } from '@/util';
+import { createLogEntry, evaluateAutomodRules, getInvalidPostRegex, getUserAccountData, performAutomodAction } from '@/util';
 import { parseReq } from '@/services/juxt-web/routes/routeUtils';
 import { WebPostPageView } from '@/services/juxt-web/views/web/postPageView';
 import { CtrPostPageView } from '@/services/juxt-web/views/ctr/postPageView';
@@ -20,6 +20,7 @@ import { PortalNewPostPage } from '@/services/juxt-web/views/portal/newPostView'
 import { PortalReportPostPage } from '@/services/juxt-web/views/portal/reportPostView';
 import { CtrReportPostPage } from '@/services/juxt-web/views/ctr/reportPostView';
 import { getShotMode, isPostingAllowed } from '@/services/juxt-web/routes/permissions';
+import { AutomodRule } from '@/models/automodRules';
 import type { Request, Response } from 'express';
 import type { InferSchemaType } from 'mongoose';
 import type { PaintingUrls } from '@/images';
@@ -456,6 +457,7 @@ async function newPost(req: Request, res: Response): Promise<void> {
 		res.sendStatus(422);
 		return;
 	}
+
 	const document = {
 		title_id: community.titleIds[0],
 		community_id: community.olive_community_id,
@@ -493,6 +495,17 @@ async function newPost(req: Request, res: Response): Promise<void> {
 	if ((document.body === '' && document.painting === '' && document.screenshot === '') || duplicatePost) {
 		return res.redirect('/titles/' + community.olive_community_id + '/new');
 	}
+
+	// Automod
+	const automodRules = await AutomodRule.find({ enabled: true });
+	const automodEval = evaluateAutomodRules(document, automodRules);
+	const automodResult = await performAutomodAction(document, automodEval);
+	if (automodResult.allowPost) {
+		res.sendStatus(422);
+		return;
+	}
+
+	// Actual posting
 	const newPost = new POST(document);
 	newPost.save();
 	if (parentPost) {

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -500,7 +500,7 @@ async function newPost(req: Request, res: Response): Promise<void> {
 	const automodRules = await AutomodRule.find({ enabled: true });
 	const automodEval = evaluateAutomodRules(document, automodRules);
 	const automodResult = await performAutomodAction(document, automodEval);
-	if (automodResult.allowPost) {
+	if (!automodResult.allowPost) {
 		res.sendStatus(422);
 		return;
 	}

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -28,6 +28,7 @@ import type { PostPageViewProps } from '@/services/juxt-web/views/web/postPageVi
 import type { HydratedSettingsDocument } from '@/models/settings';
 import type { ContentSchema } from '@/models/content';
 import type { EmpathyActionEnum } from '@/api/generated';
+import type { NewPostViewProps } from '@/services/juxt-web/views/web/newPostView';
 const storage = multer.memoryStorage();
 const upload = multer({ storage });
 export const postsRouter = express.Router();
@@ -245,9 +246,12 @@ postsRouter.post('/:post_id/new', postLimit, upload.fields([{ name: 'shot', maxC
 });
 
 postsRouter.get('/:post_id/create', async function (req, res) {
-	const { params, auth } = parseReq(req, {
+	const { params, auth, query } = parseReq(req, {
 		params: z.object({
 			post_id: z.string()
+		}),
+		query: z.object({
+			'error-text': z.string().optional()
 		})
 	});
 
@@ -263,13 +267,14 @@ postsRouter.get('/:post_id/create', async function (req, res) {
 
 	const shotMode = getShotMode(community, auth().paramPackData);
 
-	const props = {
+	const props: NewPostViewProps = {
 		id: parent.community_id,
 		pid: parent.pid,
 		url: `/posts/${parent.id}/new`,
 		show: 'post',
 		shotMode,
-		community
+		community,
+		errorText: query['error-text']
 	};
 	res.jsxForDirectory({
 		ctr: <CtrNewPostPage {...props} />,
@@ -352,6 +357,7 @@ async function newPost(req: Request, res: Response): Promise<void> {
 		}),
 		files: ['shot']
 	});
+	const rejectReturnUrl = params.post_id ? `/posts/${params.post_id}/create` : `/titles/${body.community_id}/create`;
 
 	const userSettings = await database.getUserSettings(auth().pid);
 	let parentPost = null;
@@ -501,8 +507,9 @@ async function newPost(req: Request, res: Response): Promise<void> {
 	const automodEval = evaluateAutomodRules(document, automodRules);
 	const automodResult = await performAutomodAction(document, automodEval);
 	if (!automodResult.allowPost) {
-		res.sendStatus(422);
-		return;
+		const params = new URLSearchParams();
+		params.append('error-text', res.i18n.t('new_post.automod_error'));
+		return res.redirect(rejectReturnUrl + '?' + params.toString());
 	}
 
 	// Actual posting

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/index.ts
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/index.ts
@@ -6,9 +6,9 @@ import { feedRouter } from '@/services/juxt-web/routes/console/feed';
 import { notificationRouter } from '@/services/juxt-web/routes/console/notifications';
 import { topicsRouter } from '@/services/juxt-web/routes/console/topics';
 import { loginRouter } from '@/services/juxt-web/routes/web/login';
-import { adminRouter } from '@/services/juxt-web/routes/admin/admin';
 import { staticRouter } from '@/services/juxt-web/routes/console/static';
 import { entrypointRouter } from '@/services/juxt-web/routes/console/entrypoint';
+import { baseAdminRouter } from '@/services/juxt-web/routes/admin';
 
 export const routes = {
 	PORTAL_SHOW: showRouter,
@@ -19,7 +19,7 @@ export const routes = {
 	PORTAL_NEWS: notificationRouter,
 	PORTAL_TOPICS: topicsRouter,
 	WEB_LOGIN: loginRouter,
-	ADMIN: adminRouter,
+	ADMIN: baseAdminRouter,
 	STATIC: staticRouter,
 	ENTRYPOINT: entrypointRouter
 };

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/newPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/newPostView.tsx
@@ -119,6 +119,7 @@ export function CtrNewPostView(props: NewPostViewProps): ReactNode {
 						</div>
 					</CtrTabsView>
 				</div>
+				{props.errorText ? <p>{props.errorText}</p> : null}
 				<input id="message_to_pid" type="hidden" name="message_to_pid" value={props.messagePid ?? undefined} />
 				<input
 					type="submit"

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/newPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/newPostView.tsx
@@ -123,6 +123,7 @@ export function PortalNewPostView(props: NewPostViewProps): ReactNode {
 							</li>
 						</menu>
 					</div>
+					{props.errorText ? <p>{props.errorText}</p> : null}
 					<label className="checkbox-container spoiler-button">
 						<T k="new_post.spoiler_label" />
 						<input type="checkbox" id="spoiler" name="spoiler" value="true" />

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/admin.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/admin.tsx
@@ -3,7 +3,7 @@ import { useUser } from '@/services/juxt-web/views/common/hooks/useUser';
 import type { ReactNode } from 'react';
 
 export type ModerationTabsProps = {
-	selected: 'users' | 'reports' | 'communities';
+	selected: 'users' | 'reports' | 'automod' | 'communities';
 };
 
 export function WebModerationTabs(props: ModerationTabsProps): ReactNode {
@@ -19,6 +19,15 @@ export function WebModerationTabs(props: ModerationTabsProps): ReactNode {
 				href="/admin/posts"
 			>
 				Posts
+			</a>
+			<a
+				id="post-automod"
+				className={cx({
+					selected: props.selected === 'automod'
+				})}
+				href="/admin/posts/logs"
+			>
+				Automod
 			</a>
 			<a
 				id="account-reports"

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/admin.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/admin.tsx
@@ -25,7 +25,7 @@ export function WebModerationTabs(props: ModerationTabsProps): ReactNode {
 				className={cx({
 					selected: props.selected === 'automod'
 				})}
-				href="/admin/posts/logs"
+				href="/admin/automod"
 			>
 				Automod
 			</a>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
@@ -2,6 +2,9 @@ import { WebRoot, WebWrapper } from '@/services/juxt-web/views/web/root';
 import { WebNavBar } from '@/services/juxt-web/views/web/navbar';
 import { WebModerationTabs } from '@/services/juxt-web/views/web/admin/admin';
 import { useUrl } from '@/services/juxt-web/views/common/hooks/useUrl';
+import { WebMiiIcon } from '@/services/juxt-web/views/web/components/ui/WebMiiIcon';
+import { useCache } from '@/services/juxt-web/views/common/hooks/useCache';
+import { humanDate, humanFromNow } from '@/util';
 import type { ReactNode } from 'react';
 import type { AutomodLog } from '@/api/generated';
 
@@ -17,11 +20,40 @@ export type AutomodLogListViewProps = {
 };
 
 function AutomodLogItem({ log }: AutomodLogItemViewProps): ReactNode {
+	const cache = useCache();
+
 	return (
-		<li>
-			Log
-			{' '}
-			{log.id}
+		<li className="reports">
+			<div className="hover">
+				<WebMiiIcon pid={log.postAuthor} type="icon" />
+				<span className="body messages report">
+					<span className="text">
+						{`Post ${log.action} by `}
+						<a className="nick-name" href={`/users/${log.postAuthor}`}>
+							{cache.getUserName(log.postAuthor)}
+						</a>
+						{' - '}
+						<span className="pid-display">{log.postAuthor}</span>
+						{' - '}
+						<abbr className="timestamp" title={humanDate(log.createdAt)}>{humanFromNow(log.createdAt)}</abbr>
+					</span>
+					<span className="text">
+						<p>
+							<span className="pid-display">Triggered by </span>
+							<span>{log.rule.title}</span>
+						</p>
+					</span>
+					<span className="text">
+						<h4>Body:</h4>
+						<p>
+							{log.postContent?.body ?? 'NO BODY'}
+						</p>
+					</span>
+				</span>
+			</div>
+			<div className="button-spacer">
+				{ log.postId ? <a href={`/posts/${log.postId}`}>Go to post</a> : null }
+			</div>
 		</li>
 	);
 }

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
@@ -19,7 +19,7 @@ export type AutomodLogListViewProps = {
 function AutomodLogItem({ log }: AutomodLogItemViewProps): ReactNode {
 	return (
 		<li>
-			Test
+			Log
 			{' '}
 			{log.id}
 		</li>
@@ -43,6 +43,9 @@ export function WebAutomodLogListView(props: AutomodLogListViewProps): ReactNode
 			<div id="toast"></div>
 			<WebWrapper>
 				<WebModerationTabs selected="automod" />
+				<button style={{ marginTop: '1em' }}>
+					<a href="/admin/automod/rules" className="button">View rules</a>
+				</button>
 				{props.items.length === 0
 					? (
 							<p>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
@@ -37,8 +37,7 @@ export function WebAutomodLogListView(props: AutomodLogListViewProps): ReactNode
 				Automod (
 				{props.total}
 				{' '}
-				logs
-				)
+				logs)
 			</h2>
 			<WebNavBar selection={5} />
 			<div id="toast"></div>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
@@ -1,0 +1,66 @@
+import { WebRoot, WebWrapper } from '@/services/juxt-web/views/web/root';
+import { WebNavBar } from '@/services/juxt-web/views/web/navbar';
+import { WebModerationTabs } from '@/services/juxt-web/views/web/admin/admin';
+import { useUrl } from '@/services/juxt-web/views/common/hooks/useUrl';
+import type { ReactNode } from 'react';
+import type { AutomodLog } from '@/api/generated';
+
+export type AutomodLogItemViewProps = {
+	log: AutomodLog;
+};
+
+export type AutomodLogListViewProps = {
+	total: number;
+	items: AutomodLog[];
+	page: number;
+	hasNextPage: boolean;
+};
+
+function AutomodLogItem({ log }: AutomodLogItemViewProps): ReactNode {
+	return (
+		<li>
+			Test
+			{' '}
+			{log.id}
+		</li>
+	);
+}
+
+export function WebAutomodLogListView(props: AutomodLogListViewProps): ReactNode {
+	const url = useUrl();
+	const prevUrl = url.url('/admin/automod', { page: props.page - 1 });
+	const nextUrl = url.url('/admin/automod', { page: props.page + 1 });
+
+	return (
+		<WebRoot type="admin">
+			<h2 id="title" className="page-header">
+				Automod (
+				{props.total}
+				{' '}
+				logs
+				)
+			</h2>
+			<WebNavBar selection={5} />
+			<div id="toast"></div>
+			<WebWrapper>
+				<WebModerationTabs selected="automod" />
+				{props.items.length === 0
+					? (
+							<p>
+								No logs found
+							</p>
+						)
+					: null }
+				<ul className="list-content-with-icon-and-text arrow-list accounts" id="news-list-content">
+					{props.items.map(log => (
+						<AutomodLogItem log={log} key={log.id} />
+					))}
+				</ul>
+				<div className="buttons tabs">
+					{ props.page > 0 ? <a href={prevUrl} className="button">Previous Page</a> : null }
+					{ props.hasNextPage ? <a href={nextUrl} className="button">Next Page</a> : null }
+				</div>
+			</WebWrapper>
+		</WebRoot>
+	);
+}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodRuleCreateView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodRuleCreateView.tsx
@@ -1,0 +1,59 @@
+import { WebRoot, WebWrapper } from '@/services/juxt-web/views/web/root';
+import { WebNavBar } from '@/services/juxt-web/views/web/navbar';
+import { WebModerationTabs } from '@/services/juxt-web/views/web/admin/admin';
+import type { ReactNode } from 'react';
+
+type DropdownProps = {
+	name: string;
+	id?: string;
+	value?: string | number;
+};
+
+export function WebAutomodRuleTypeDropdown(props: DropdownProps): ReactNode {
+	return (
+		<select className="form-select" value={props.value} name={props.name} id={props.id}>
+			<option value="keyword">Keyword</option>
+		</select>
+	);
+}
+
+export function WebAutomodRuleModeDropdown(props: DropdownProps): ReactNode {
+	return (
+		<select className="form-select" value={props.value} name={props.name} id={props.id}>
+			<option value="block">Block post</option>
+			<option value="log">Allow & log</option>
+		</select>
+	);
+}
+
+export function WebAutomodRuleCreateView(): ReactNode {
+	return (
+		<WebRoot type="admin">
+			<h2 id="title" className="page-header">
+				New automod rule
+			</h2>
+			<WebNavBar selection={5} />
+			<div id="toast"></div>
+			<WebWrapper className="community-create">
+				<WebModerationTabs selected="automod" />
+				<form action="/admin/automod/rules/create" method="post">
+					<div className="col-md-3">
+						<label className="labels" htmlFor="rule-title">Title:</label>
+						<input type="text" id="rule-title" name="title" className="form-control" value="" placeholder="Name of your rule" required />
+					</div>
+					<div className="col-md-3">
+						<label className="labels" htmlFor="rule-type">Rule type</label>
+						<WebAutomodRuleTypeDropdown name="type" id="rule-type" />
+					</div>
+					<div className="col-md-3">
+						<label className="labels" htmlFor="rule-mode">Rule mode</label>
+						<WebAutomodRuleModeDropdown name="mode" id="rule-mode" />
+					</div>
+					<div className="col-md-3">
+						<button className="btn btn-primary profile-button" type="submit">Create rule</button>
+					</div>
+				</form>
+			</WebWrapper>
+		</WebRoot>
+	);
+}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodRuleListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodRuleListView.tsx
@@ -8,6 +8,7 @@ import type { AutomodRule } from '@/api/generated';
 
 export type AutomodRuleItemViewProps = {
 	rule: AutomodRule;
+	canEdit?: boolean;
 };
 
 export type AutomodRuleListViewProps = {
@@ -15,19 +16,13 @@ export type AutomodRuleListViewProps = {
 	items: AutomodRule[];
 	page: number;
 	hasNextPage: boolean;
+	canEdit?: boolean;
 };
 
-function AutomodRuleItem({ rule }: AutomodRuleItemViewProps): ReactNode {
-	return (
-		<li className="reports">
-			<span className="body messages report">
-				<h4 className="text" style={{ textDecoration: rule.enabled ? 'none' : 'line-through' }}>
-					{rule.title}
-					{' '}
-					<span className="pid-display">{`${rule.type} - ${rule.mode}`}</span>
-				</h4>
-				{rule.description ? <span>{rule.description}</span> : null}
-			</span>
+function AutomodRuleItem({ rule, canEdit }: AutomodRuleItemViewProps): ReactNode {
+	let editSection: ReactNode = null;
+	if (canEdit) {
+		editSection = (
 			<details className="community-create" style={{ marginTop: '1rem' }}>
 				<summary>Edit</summary>
 				<form action={`/admin/automod/rules/${rule.id}/update`} method="post">
@@ -74,6 +69,20 @@ function AutomodRuleItem({ rule }: AutomodRuleItemViewProps): ReactNode {
 					</div>
 				</form>
 			</details>
+		);
+	}
+
+	return (
+		<li className="reports" style={{ width: 500 }}>
+			<span className="body messages report">
+				<h4 className="text" style={{ textDecoration: rule.enabled ? 'none' : 'line-through' }}>
+					{rule.title}
+					{' '}
+					<span className="pid-display">{`${rule.type} - ${rule.mode}`}</span>
+				</h4>
+				{rule.description ? <span>{rule.description}</span> : null}
+			</span>
+			{editSection}
 		</li>
 	);
 }
@@ -92,9 +101,13 @@ export function WebAutomodRuleListView(props: AutomodRuleListViewProps): ReactNo
 			<div id="toast"></div>
 			<WebWrapper>
 				<WebModerationTabs selected="automod" />
-				<button style={{ marginTop: '1em' }}>
-					<a href="/admin/automod/rules/create" className="button">New rule</a>
-				</button>
+				{ props.canEdit
+					? (
+							<button style={{ marginTop: '1em' }}>
+								<a href="/admin/automod/rules/create" className="button">New rule</a>
+							</button>
+						)
+					: null}
 				{props.items.length === 0
 					? (
 							<p>
@@ -104,7 +117,7 @@ export function WebAutomodRuleListView(props: AutomodRuleListViewProps): ReactNo
 					: null }
 				<ul className="list-content-with-icon-and-text arrow-list accounts" id="news-list-content">
 					{props.items.map(rule => (
-						<AutomodRuleItem rule={rule} key={rule.id} />
+						<AutomodRuleItem rule={rule} key={rule.id} canEdit={props.canEdit} />
 					))}
 				</ul>
 				<div className="buttons tabs">

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodRuleListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodRuleListView.tsx
@@ -1,0 +1,117 @@
+import { WebRoot, WebWrapper } from '@/services/juxt-web/views/web/root';
+import { WebNavBar } from '@/services/juxt-web/views/web/navbar';
+import { WebModerationTabs } from '@/services/juxt-web/views/web/admin/admin';
+import { useUrl } from '@/services/juxt-web/views/common/hooks/useUrl';
+import { WebAutomodRuleModeDropdown, WebAutomodRuleTypeDropdown } from '@/services/juxt-web/views/web/admin/automodRuleCreateView';
+import type { ReactNode } from 'react';
+import type { AutomodRule } from '@/api/generated';
+
+export type AutomodRuleItemViewProps = {
+	rule: AutomodRule;
+};
+
+export type AutomodRuleListViewProps = {
+	total: number;
+	items: AutomodRule[];
+	page: number;
+	hasNextPage: boolean;
+};
+
+function AutomodRuleItem({ rule }: AutomodRuleItemViewProps): ReactNode {
+	return (
+		<li className="reports">
+			<span className="body messages report">
+				<h4 className="text" style={{ textDecoration: rule.enabled ? 'none' : 'line-through' }}>
+					{rule.title}
+					{' '}
+					<span className="pid-display">{`${rule.type} - ${rule.mode}`}</span>
+				</h4>
+				{rule.description ? <span>{rule.description}</span> : null}
+			</span>
+			<details className="community-create" style={{ marginTop: '1rem' }}>
+				<summary>Edit</summary>
+				<form action={`/admin/automod/rules/${rule.id}/update`} method="post">
+					<div className="col-md-3">
+						<label className="labels" htmlFor="rule-title">Title:</label>
+						<input type="text" id="rule-title" name="title" className="form-control" value={rule.title} placeholder="Name of your rule" required />
+					</div>
+					<div className="col-md-3">
+						<label className="labels" htmlFor="rule-desc">Description:</label>
+						<textarea id="rule-desc" name="description" className="form-control" value={rule.description ?? ''} placeholder="Description of your rule" />
+					</div>
+					<div className="col-md-4">
+						<label className="form-check-label" htmlFor="enabled">Enabled:</label>
+						<div className="form-switch">
+							<input className="form-check-input" type="checkbox" checked={rule.enabled} id="enabled" name="enabled" />
+						</div>
+					</div>
+					<div className="col-md-3">
+						<label className="labels" htmlFor="rule-mode">Rule mode</label>
+						<WebAutomodRuleModeDropdown name="mode" value={rule.mode} id="rule-mode" />
+					</div>
+					<div className="col-md-3">
+						<label className="labels" htmlFor="rule-type">Rule type</label>
+						<WebAutomodRuleTypeDropdown name="type" value={rule.type} id="rule-type" />
+					</div>
+					{ rule.type === 'keyword'
+						? (
+								<>
+									<div className="col-md-3">
+										<label className="labels" htmlFor="keywordSettingsKeywords">Keywords (1 per line):</label>
+										<textarea id="keywordSettingsKeywords" name="keywordSettingsKeywords" className="form-control" value={rule.settings?.keyword?.keywords.join('\n') ?? ''} />
+									</div>
+								</>
+							)
+						: null}
+					<div className="button-spacer">
+						<button type="submit">Save</button>
+					</div>
+				</form>
+				<hr />
+				<form action={`/admin/automod/rules/${rule.id}/delete`} method="post">
+					<div className="button-spacer">
+						<button type="submit">Delete</button>
+					</div>
+				</form>
+			</details>
+		</li>
+	);
+}
+
+export function WebAutomodRuleListView(props: AutomodRuleListViewProps): ReactNode {
+	const url = useUrl();
+	const prevUrl = url.url('/admin/automod/rules', { page: props.page - 1 });
+	const nextUrl = url.url('/admin/automod/rules', { page: props.page + 1 });
+
+	return (
+		<WebRoot type="admin">
+			<h2 id="title" className="page-header">
+				Automod rules
+			</h2>
+			<WebNavBar selection={5} />
+			<div id="toast"></div>
+			<WebWrapper>
+				<WebModerationTabs selected="automod" />
+				<button style={{ marginTop: '1em' }}>
+					<a href="/admin/automod/rules/create" className="button">New rule</a>
+				</button>
+				{props.items.length === 0
+					? (
+							<p>
+								No rules found
+							</p>
+						)
+					: null }
+				<ul className="list-content-with-icon-and-text arrow-list accounts" id="news-list-content">
+					{props.items.map(rule => (
+						<AutomodRuleItem rule={rule} key={rule.id} />
+					))}
+				</ul>
+				<div className="buttons tabs">
+					{ props.page > 0 ? <a href={prevUrl} className="button">Previous Page</a> : null }
+					{ props.hasNextPage ? <a href={nextUrl} className="button">Next Page</a> : null }
+				</div>
+			</WebWrapper>
+		</WebRoot>
+	);
+}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/newPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/newPostView.tsx
@@ -56,6 +56,9 @@ export type NewPostViewProps = {
 	messagePid?: number;
 	community?: Community;
 	shotMode: CommunityShotMode;
+
+	// Error feedback
+	errorText?: string;
 };
 
 export function WebNewPostView(props: NewPostViewProps): ReactNode {
@@ -64,6 +67,7 @@ export function WebNewPostView(props: NewPostViewProps): ReactNode {
 	return (
 		<div id="add-post-page" className="add-post-page official-user-post" style={{ display: 'none' }}>
 			<form method="post" action={props.url} id="posts-form" data-is-own-title="1" data-is-identified="1">
+				{props.errorText ? <p>{props.errorText}</p> : null}
 				<input type="hidden" name="community_id" value={props.id} />
 				<div className="add-post-page-content">
 					<div className="feeling-selector expression">

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -20,6 +20,7 @@ import { LOGS } from '@/models/logs';
 import { config } from '@/config';
 import { SystemType } from '@/types/common/system-types';
 import { TokenType } from '@/types/common/token-types';
+import { AutomodLog } from '@/models/automodLog';
 import type { ZodType } from 'zod';
 import type { ObjectCannedACL } from '@aws-sdk/client-s3';
 import type { InferSchemaType } from 'mongoose';
@@ -28,11 +29,13 @@ import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonet
 import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
 import type { LoginResponse } from '@pretendonetwork/grpc/api/login_rpc';
 import type { GetUserFriendPIDsResponse } from '@pretendonetwork/grpc/friends/get_user_friend_pids_rpc';
+import type { AutomodAction } from '@/models/automodLog';
 import type { NotificationCreateArgs } from '@/types/juxt/notification';
 import type { ServiceToken } from '@/types/common/service-token';
 import type { ParamPack } from '@/types/common/param-pack';
 import type { CommunitySchema } from '@/models/communities';
 import type { NotificationSchema } from '@/models/notifications';
+import type { HydratedAutomodRuleDocument } from '@/models/automodRules';
 
 const gRPCFriendsChannel = createChannel(`${config.grpc.friends.host}:${config.grpc.friends.port}`);
 const gRPCFriendsClient = createClient(FriendsDefinition, gRPCFriendsChannel);
@@ -437,6 +440,58 @@ export async function passwordLogin(username: string, password: string): Promise
 // 		})
 // 	});
 // }
+
+export type AutomodRuleEvaluation = {
+	violatedRule: HydratedAutomodRuleDocument;
+	action: AutomodAction;
+} | null;
+
+export function evaluateAutomodRules(post: any, rules: HydratedAutomodRuleDocument[]): AutomodRuleEvaluation {
+	const blockRules = rules.filter(v => v.mode === 'block');
+	const nonBlockRules = rules.filter(v => v.mode !== 'block');
+	const orderedRules = [...blockRules, ...nonBlockRules];
+
+	for (const rule of orderedRules) {
+		let hasMatched = false;
+		if (rule.type === 'keyword') {
+			const bodyNormalized = (post.body ?? '').toLowerCase();
+			const keywordsToCheck = rule.keyword_settings?.keywords ?? [];
+			const matchedKeywords = keywordsToCheck.filter(keyword => bodyNormalized.includes(keyword.toLowerCase()));
+			hasMatched = matchedKeywords.length > 0;
+		}
+
+		if (hasMatched) {
+			return {
+				action: rule.mode === 'block' ? 'blocked' : 'logged',
+				violatedRule: rule
+			};
+		}
+	}
+
+	return null; // No rules apply to this post
+}
+
+export async function performAutomodAction(post: any, evaluation: AutomodRuleEvaluation): Promise<{ allowPost: boolean }> {
+	if (!evaluation) {
+		return { allowPost: true };
+	}
+
+	if (evaluation.action === 'blocked' || evaluation.action === 'logged') {
+		const allowPost = evaluation.action === 'blocked' ? false : true;
+		await AutomodLog.create({
+			action: evaluation.action,
+			post_id: post.id,
+			post_content_body: post.body ?? '',
+			created_at: new Date(),
+			rule_id: evaluation.violatedRule.id
+		});
+		return {
+			allowPost
+		};
+	}
+
+	throw new Error('Invalid automod evaluation');
+}
 
 export async function createLogEntry(actor: number, action: string, target: string, context: string, fields?: string[]): Promise<void> {
 	const newLog = new LOGS({

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -480,6 +480,7 @@ export async function performAutomodAction(post: any, evaluation: AutomodRuleEva
 		const allowPost = evaluation.action === 'blocked' ? false : true;
 		await AutomodLog.create({
 			action: evaluation.action,
+			author: post.pid,
 			post_id: post.id,
 			post_content_body: post.body ?? '',
 			created_at: new Date(),

--- a/apps/miiverse-api/src/models/automodLog.ts
+++ b/apps/miiverse-api/src/models/automodLog.ts
@@ -1,0 +1,41 @@
+import { Schema, model } from 'mongoose';
+import type { HydratedDocument } from 'mongoose';
+
+export const automodAction = ['blocked', 'logged'] as const;
+export type AutomodAction = (typeof automodAction)[number];
+
+export type AutomodLog = {
+	rule_id: string;
+	created_at: Date;
+	action: AutomodAction;
+	post_id: string | null;
+	post_content_body: string | null;
+} & Document;
+
+export type HydratedAutomodLogDocument = HydratedDocument<AutomodLog>;
+
+export const automodLogSchema = new Schema<AutomodLog>({
+	rule_id: {
+		type: String,
+		required: true
+	},
+	created_at: {
+		type: Date,
+		required: true
+	},
+	action: {
+		type: String,
+		enum: automodAction,
+		required: true
+	},
+	post_id: {
+		type: String,
+		required: false
+	},
+	post_content_body: {
+		type: String,
+		required: false
+	}
+});
+
+export const AutomodLog = model('AutomodLog', automodLogSchema);

--- a/apps/miiverse-api/src/models/automodLog.ts
+++ b/apps/miiverse-api/src/models/automodLog.ts
@@ -7,6 +7,7 @@ export type AutomodAction = (typeof automodAction)[number];
 export type AutomodLog = {
 	rule_id: string;
 	created_at: Date;
+	author: number;
 	action: AutomodAction;
 	post_id: string | null;
 	post_content_body: string | null;
@@ -26,6 +27,10 @@ export const automodLogSchema = new Schema<AutomodLog>({
 	action: {
 		type: String,
 		enum: automodAction,
+		required: true
+	},
+	author: {
+		type: Number,
 		required: true
 	},
 	post_id: {

--- a/apps/miiverse-api/src/models/automodRules.ts
+++ b/apps/miiverse-api/src/models/automodRules.ts
@@ -1,0 +1,65 @@
+import { Schema, model } from 'mongoose';
+import type { HydratedDocument } from 'mongoose';
+
+export const automodRuleType = ['keyword'] as const;
+export type AutomodRuleType = (typeof automodRuleType)[number];
+
+export const automodRuleMode = ['block', 'log'] as const;
+export type AutomodRuleMode = (typeof automodRuleMode)[number];
+
+export type AutomodKeywordSettings = {
+	keywords: string[];
+} & Document;
+
+export type AutomodRule = {
+	enabled: boolean;
+	created_at: Date;
+	title: string;
+	description: string | null;
+	type: AutomodRuleType;
+	mode: AutomodRuleMode;
+	keyword_settings: {
+		keywords: string[];
+	};
+} & Document;
+
+export type HydratedAutomodRuleDocument = HydratedDocument<AutomodRule>;
+
+export const automodRuleKeywordSettingsSchema = new Schema<AutomodKeywordSettings>({
+	keywords: {
+		type: [String],
+		required: true
+	}
+});
+
+export const automodRuleSchema = new Schema<AutomodRule>({
+	enabled: {
+		type: Boolean,
+		required: true
+	},
+	title: {
+		type: String,
+		required: true
+	},
+	description: String,
+	type: {
+		type: String,
+		enum: automodRuleType,
+		required: true
+	},
+	mode: {
+		type: String,
+		enum: automodRuleMode,
+		required: true
+	},
+	keyword_settings: {
+		type: automodRuleKeywordSettingsSchema,
+		required: false
+	},
+	created_at: {
+		type: Date,
+		required: true
+	}
+});
+
+export const AutomodRule = model('AutomodRule', automodRuleSchema);

--- a/apps/miiverse-api/src/services/api/routes/posts.ts
+++ b/apps/miiverse-api/src/services/api/routes/posts.ts
@@ -4,7 +4,9 @@ import xmlbuilder from 'xmlbuilder';
 import * as z from 'zod';
 import {
 	getValueFromQueryString,
-	getInvalidPostRegex
+	getInvalidPostRegex,
+	evaluateAutomodRules,
+	performAutomodAction
 } from '@/util';
 import {
 	getPostByID,
@@ -21,6 +23,7 @@ import { config } from '@/config';
 import { ApiErrorCode, badRequest, serverError } from '@/errors';
 import { uploadPainting, uploadScreenshot } from '@/images';
 import { cleanedBase64 } from '@/zodUtils';
+import { AutomodRule } from '@/models/automodRules';
 import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
 import type { PostRepliesResult } from '@/types/miiverse/post';
 import type { HydratedPostDocument, IPostInput } from '@/types/mongoose/post';
@@ -403,6 +406,15 @@ async function newPost(request: express.Request, response: express.Response): Pr
 		return badRequest(response, ApiErrorCode.NOT_ALLOWED_SPAM, 403);
 	}
 
+	// Automod
+	const automodRules = await AutomodRule.find({ enabled: true });
+	const automodEval = evaluateAutomodRules(document, automodRules);
+	const automodResult = await performAutomodAction(document, automodEval);
+	if (automodResult.allowPost) {
+		return badRequest(response, ApiErrorCode.BAD_WORDS_FILTER);
+	}
+
+	// Actual posting
 	const post = await Post.create(document);
 
 	if (painting) {

--- a/apps/miiverse-api/src/services/api/routes/posts.ts
+++ b/apps/miiverse-api/src/services/api/routes/posts.ts
@@ -410,7 +410,7 @@ async function newPost(request: express.Request, response: express.Response): Pr
 	const automodRules = await AutomodRule.find({ enabled: true });
 	const automodEval = evaluateAutomodRules(document, automodRules);
 	const automodResult = await performAutomodAction(document, automodEval);
-	if (automodResult.allowPost) {
+	if (!automodResult.allowPost) {
 		return badRequest(response, ApiErrorCode.BAD_WORDS_FILTER);
 	}
 

--- a/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
@@ -12,6 +12,7 @@ export const automodLogSchema = z.object({
 	createdAt: z.date(),
 	rule: shallowAutomodRuleSchema.nullable(),
 	action: automodActionEnum,
+	postAuthor: z.number(),
 	postId: z.string().nullable(),
 	postContent: z.object({
 		body: z.string().nullable()
@@ -26,6 +27,7 @@ export function mapAutomodLog(log: HydratedAutomodLogDocument, rule: HydratedAut
 		createdAt: log.created_at,
 		rule: rule ? mapShallowAutomodRule(rule) : null,
 		action: log.action,
+		postAuthor: log.author,
 		postId: log.post_id,
 		postContent: {
 			body: log.post_content_body

--- a/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
@@ -10,7 +10,7 @@ export const automodActionEnum = asOpenapi('AutomodActionEnum', z.enum(automodAc
 export const automodLogSchema = z.object({
 	id: z.string(),
 	createdAt: z.date(),
-	rule: shallowAutomodRuleSchema,
+	rule: shallowAutomodRuleSchema.nullable(),
 	action: automodActionEnum,
 	postId: z.string().nullable(),
 	postContent: z.object({
@@ -20,11 +20,11 @@ export const automodLogSchema = z.object({
 
 export type AutomodLogDto = z.infer<typeof automodLogSchema>;
 
-export function mapAutomodLog(log: HydratedAutomodLogDocument, rule: HydratedAutomodRuleDocument): AutomodLogDto {
+export function mapAutomodLog(log: HydratedAutomodLogDocument, rule: HydratedAutomodRuleDocument | null): AutomodLogDto {
 	return {
 		id: log.id,
 		createdAt: log.created_at,
-		rule: mapShallowAutomodRule(rule),
+		rule: rule ? mapShallowAutomodRule(rule) : null,
 		action: log.action,
 		postId: log.post_id,
 		postContent: {

--- a/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
@@ -28,7 +28,7 @@ export function mapAutomodLog(log: HydratedAutomodLogDocument, rule: HydratedAut
 		rule: rule ? mapShallowAutomodRule(rule) : null,
 		action: log.action,
 		postAuthor: log.author,
-		postId: log.post_id,
+		postId: log.action === 'blocked' ? null : log.post_id,
 		postContent: {
 			body: log.post_content_body
 		}

--- a/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
@@ -16,7 +16,7 @@ export const automodLogSchema = z.object({
 	postContent: z.object({
 		body: z.string().nullable()
 	})
-}).openapi('AutomodRule');
+}).openapi('AutomodLog');
 
 export type AutomodLogDto = z.infer<typeof automodLogSchema>;
 

--- a/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { mapShallowAutomodRule, shallowAutomodRuleSchema } from '@/services/internal/contract/admin/automodRule';
+import { automodAction } from '@/models/automodLog';
+import { asOpenapi } from '@/services/internal/builder/openapi';
+import type { HydratedAutomodLogDocument } from '@/models/automodLog';
+import type { HydratedAutomodRuleDocument } from '@/models/automodRules';
+
+export const automodActionEnum = asOpenapi('AutomodActionEnum', z.enum(automodAction));
+
+export const automodLogSchema = z.object({
+	id: z.string(),
+	createdAt: z.date(),
+	rule: shallowAutomodRuleSchema,
+	action: automodActionEnum,
+	postId: z.string().nullable(),
+	postContent: z.object({
+		body: z.string().nullable()
+	})
+}).openapi('AutomodRule');
+
+export type AutomodLogDto = z.infer<typeof automodLogSchema>;
+
+export function mapAutomodLog(log: HydratedAutomodLogDocument, rule: HydratedAutomodRuleDocument): AutomodLogDto {
+	return {
+		id: log.id,
+		createdAt: log.created_at,
+		rule: mapShallowAutomodRule(rule),
+		action: log.action,
+		postId: log.post_id,
+		postContent: {
+			body: log.post_content_body
+		}
+	};
+}

--- a/apps/miiverse-api/src/services/internal/contract/admin/automodRule.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/automodRule.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+import { automodRuleMode, automodRuleType } from '@/models/automodRules';
+import { asOpenapi } from '@/services/internal/builder/openapi';
+import type { HydratedAutomodRuleDocument } from '@/models/automodRules';
+
+export const automodRuleTypeEnum = asOpenapi('AutomodRuleTypeEnum', z.enum(automodRuleType));
+export const automodRuleModeEnum = asOpenapi('AutomodRuleModeEnum', z.enum(automodRuleMode));
+
+export const automodRuleSchema = z.object({
+	id: z.string(),
+	createdAt: z.date(),
+	enabled: z.boolean(),
+	type: automodRuleTypeEnum,
+	mode: automodRuleModeEnum,
+	title: z.string(),
+	description: z.string().nullable(),
+	settings: z.object({
+		keyword: z.object({
+			keywords: z.array(z.string())
+		}).nullable()
+	})
+}).openapi('AutomodRule');
+
+export type AutomodRuleDto = z.infer<typeof automodRuleSchema>;
+
+export const shallowAutomodRuleSchema = asOpenapi('ShallowAutomodRule', z.object({
+	id: z.string(),
+	type: automodRuleTypeEnum,
+	mode: automodRuleModeEnum,
+	title: z.string(),
+	description: z.string().nullable()
+}));
+
+export type ShallowAutomodRuleDto = z.infer<typeof shallowAutomodRuleSchema>;
+
+export function mapShallowAutomodRule(rule: HydratedAutomodRuleDocument): ShallowAutomodRuleDto {
+	return {
+		id: rule.id,
+		type: rule.type,
+		mode: rule.mode,
+		title: rule.title,
+		description: rule.description
+	};
+}
+
+export function mapAutomodRule(rule: HydratedAutomodRuleDocument): AutomodRuleDto {
+	return {
+		id: rule.id,
+		createdAt: rule.created_at,
+		enabled: rule.enabled,
+		type: rule.type,
+		mode: rule.mode,
+		title: rule.title,
+		description: rule.description,
+		settings: {
+			keyword: rule.keyword_settings
+				? {
+						keywords: rule.keyword_settings.keywords
+					}
+				: null
+		}
+	};
+}

--- a/apps/miiverse-api/src/services/internal/index.ts
+++ b/apps/miiverse-api/src/services/internal/index.ts
@@ -3,9 +3,11 @@ import { postsRouter } from '@/services/internal/routes/posts';
 import { communitiesRouter } from '@/services/internal/routes/communities';
 import { activityFeedsRouter } from '@/services/internal/routes/activityFeeds';
 import { communityPostsRouter } from '@/services/internal/routes/communityPosts';
+import { adminAutomodRouter } from '@/services/internal/routes/admin/adminAutomod';
 
 export const internalApiRouter = express.Router();
 internalApiRouter.use('/api/v1', postsRouter.toRouter());
 internalApiRouter.use('/api/v1', communitiesRouter.toRouter());
 internalApiRouter.use('/api/v1', activityFeedsRouter.toRouter());
 internalApiRouter.use('/api/v1', communityPostsRouter.toRouter());
+internalApiRouter.use('/api/v1', adminAutomodRouter.toRouter());

--- a/apps/miiverse-api/src/services/internal/middleware/auth-populate.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/auth-populate.ts
@@ -31,8 +31,9 @@ export async function authPopulate(request: express.Request, response: express.R
 		const content = await getUserContent(pnid.pid);
 
 		const moderator = accountIsModerator(pnid);
+		const developer = accountIsDeveloper(pnid);
 
-		response.locals.account = { pnid, settings, moderator, content };
+		response.locals.account = { pnid, settings, moderator, developer, content };
 	} else {
 		// Guest access
 		response.locals.account = null;
@@ -75,6 +76,14 @@ function accountIsModerator(pnid: GetUserDataResponse): boolean {
 
 	// Lower-level accounts can also have permission granted
 	if (pnid.permissions?.moderateMiiverse === true) {
+		return true;
+	}
+
+	return false;
+}
+
+function accountIsDeveloper(pnid: GetUserDataResponse): boolean {
+	if (pnid.accessLevel === 3) {
 		return true;
 	}
 

--- a/apps/miiverse-api/src/services/internal/middleware/guards.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/guards.ts
@@ -48,8 +48,27 @@ export async function moderator(request: express.Request, response: express.Resp
 	return next();
 }
 
+/**
+ * Developers only
+ */
+export async function developer(request: express.Request, response: express.Response, next: express.NextFunction): Promise<void> {
+	return guards.user(request, response, () => {
+		const account = response.locals.account;
+		if (account === null) {
+			throw new errors.unauthorized('Authentication token not provided');
+		}
+
+		if (account.developer !== true) {
+			throw new errors.forbidden('You cannot access this endpoint');
+		}
+
+		return next();
+	});
+}
+
 export const guards = {
 	guest,
 	user,
-	moderator
+	moderator,
+	developer
 };

--- a/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
+++ b/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
@@ -139,7 +139,7 @@ adminAutomodRouter.get({
 	guard: guards.moderator,
 	schema: {
 		query: z.object({
-			action: z.enum(automodAction),
+			action: z.enum(automodAction).optional(),
 			sort: standardSortSchema
 		}).extend(pageControlSchema(150)),
 		response: pageDtoSchema(automodLogSchema)

--- a/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
+++ b/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
@@ -44,7 +44,7 @@ adminAutomodRouter.post({
 	path: '/admin/automod-rules',
 	name: 'admin.automodRules.create',
 	description: 'Create a initial start of a rule, use the update endpoint for the rest of the fields',
-	guard: guards.moderator,
+	guard: guards.developer,
 	schema: {
 		body: z.object({
 			title: z.string(),
@@ -69,7 +69,7 @@ adminAutomodRouter.post({
 adminAutomodRouter.patch({
 	path: '/admin/automod-rules/:id',
 	name: 'admin.automodRules.update',
-	guard: guards.moderator,
+	guard: guards.developer,
 	schema: {
 		params: z.object({
 			id: z.string()
@@ -116,7 +116,7 @@ adminAutomodRouter.patch({
 adminAutomodRouter.delete({
 	path: '/admin/automod-rules/:id',
 	name: 'admin.automodRules.delete',
-	guard: guards.moderator,
+	guard: guards.developer,
 	schema: {
 		params: z.object({
 			id: z.string()

--- a/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
+++ b/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
@@ -1,0 +1,167 @@
+import { z } from 'zod';
+import { createInternalApiRouter } from '@/services/internal/builder/router';
+import { guards } from '@/services/internal/middleware/guards';
+import { deleteOptional } from '@/services/internal/utils';
+import { standardSortSchema, standardSortToDirection } from '@/services/internal/contract/utils';
+import { mapPage, pageControlSchema, pageDtoSchema } from '@/services/internal/contract/page';
+import { automodRuleSchema, mapAutomodRule } from '@/services/internal/contract/admin/automodRule';
+import { AutomodRule, automodRuleMode, automodRuleType } from '@/models/automodRules';
+import { errors } from '@/services/internal/errors';
+import { mapResult, resultSchema } from '@/services/internal/contract/result';
+import { automodLogSchema, mapAutomodLog } from '@/services/internal/contract/admin/automodLog';
+import { automodAction, AutomodLog } from '@/models/automodLog';
+import type { RootFilterQuery } from 'mongoose';
+
+export const adminAutomodRouter = createInternalApiRouter();
+
+adminAutomodRouter.get({
+	path: '/admin/automod-rules',
+	name: 'admin.automodRules.list',
+	guard: guards.moderator,
+	schema: {
+		query: z.object({
+			enabled: z.stringbool().optional(),
+			sort: standardSortSchema
+		}).extend(pageControlSchema(50)),
+		response: pageDtoSchema(automodRuleSchema)
+	},
+	async handler({ query }) {
+		const dbQuery: RootFilterQuery<AutomodRule> = deleteOptional({
+			enabled: query.enabled
+		});
+		const rules = await AutomodRule
+			.find(dbQuery)
+			.sort({ created_at: standardSortToDirection(query.sort) })
+			.skip(query.offset)
+			.limit(query.limit);
+		const total = await AutomodRule.countDocuments(dbQuery);
+
+		return mapPage(total, rules.map(v => mapAutomodRule(v)));
+	}
+});
+
+adminAutomodRouter.post({
+	path: '/admin/automod-rules',
+	name: 'admin.automodRules.create',
+	description: 'Create a initial start of a rule, use the update endpoint for the rest of the fields',
+	guard: guards.moderator,
+	schema: {
+		body: z.object({
+			title: z.string(),
+			type: z.enum(automodRuleType),
+			mode: z.enum(automodRuleMode)
+		}),
+		response: automodRuleSchema
+	},
+	async handler({ body }) {
+		const rule = await AutomodRule.create({
+			title: body.title,
+			enabled: false,
+			created_at: new Date(),
+			type: body.type,
+			mode: body.mode
+		});
+
+		return mapAutomodRule(rule);
+	}
+});
+
+adminAutomodRouter.patch({
+	path: '/admin/automod-rules/:id',
+	name: 'admin.automodRules.update',
+	guard: guards.moderator,
+	schema: {
+		params: z.object({
+			id: z.string()
+		}),
+		body: z.object({
+			title: z.string().trim().min(1),
+			description: z.string().trim().nullable(),
+			enabled: z.boolean(),
+			type: z.enum(automodRuleType),
+			mode: z.enum(automodRuleMode),
+			settings: z.object({
+				keyword: z.object({
+					keywords: z.array(z.string().min(1))
+				}).optional()
+			})
+		}).partial(),
+		response: automodRuleSchema
+	},
+	async handler({ params, body }) {
+		const desc = body.description ?? '';
+		const rule = await AutomodRule.findOneAndUpdate({ _id: params.id }, {
+			$set: deleteOptional({
+				title: body.title,
+				description: desc.length > 0 ? desc : null,
+				enabled: body.enabled,
+				type: body.type,
+				mode: body.mode,
+				keyword_settings: body.settings?.keyword
+					? {
+							keywords: body.settings.keyword.keywords
+						}
+					: undefined
+			})
+		});
+
+		if (!rule) {
+			throw new errors.notFound('Resource could not be found');
+		}
+
+		return mapAutomodRule(rule);
+	}
+});
+
+adminAutomodRouter.delete({
+	path: '/admin/automod-rules/:id',
+	name: 'admin.automodRules.delete',
+	guard: guards.moderator,
+	schema: {
+		params: z.object({
+			id: z.string()
+		}),
+		response: resultSchema
+	},
+	async handler({ params }) {
+		const rule = await AutomodRule.findOneAndDelete({ _id: params.id });
+		if (!rule) {
+			throw new errors.notFound('Resource could not be found');
+		}
+
+		return mapResult('success');
+	}
+});
+
+adminAutomodRouter.get({
+	path: '/admin/automod-logs',
+	name: 'admin.automodLogs.list',
+	guard: guards.moderator,
+	schema: {
+		query: z.object({
+			action: z.enum(automodAction),
+			sort: standardSortSchema
+		}).extend(pageControlSchema(150)),
+		response: pageDtoSchema(automodLogSchema)
+	},
+	async handler({ query }) {
+		const dbQuery: RootFilterQuery<AutomodLog> = deleteOptional({
+			action: query.action
+		});
+		const logs = await AutomodLog
+			.find(dbQuery)
+			.sort({ created_at: standardSortToDirection(query.sort) })
+			.skip(query.offset)
+			.limit(query.limit);
+		const total = await AutomodLog.countDocuments(dbQuery);
+
+		const ruleIds = logs.map(v => v.rule_id);
+		const rules = await AutomodRule.find({
+			_id: {
+				$in: ruleIds
+			}
+		});
+
+		return mapPage(total, logs.map(log => mapAutomodLog(log, rules.find(v => v.id === log.rule_id) ?? null)));
+	}
+});

--- a/apps/miiverse-api/src/types/common/account-data.ts
+++ b/apps/miiverse-api/src/types/common/account-data.ts
@@ -7,4 +7,5 @@ export interface AccountData {
 	settings: HydratedSettingsDocument | null;
 	content: HydratedContentDocument | null;
 	moderator: boolean;
+	developer: boolean;
 }

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -7,14 +7,18 @@ import { SystemType } from '@/types/common/system-types';
 import { TokenType } from '@/types/common/token-types';
 import { grpcAccount, grpcApi, grpcFriends } from '@/grpc';
 import { getS3 } from '@/s3';
+import { AutomodLog } from '@/models/automodLog';
 import type { IncomingHttpHeaders } from 'node:http';
 import type { ObjectCannedACL } from '@aws-sdk/client-s3';
 import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
 import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
 import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/get_user_data_rpc';
 import type { ParsedQs } from 'qs';
+import type { AutomodAction } from '@/models/automodLog';
 import type { ParamPack } from '@/types/common/param-pack';
 import type { ServiceToken } from '@/types/common/service-token';
+import type { IPostInput } from '@/types/mongoose/post';
+import type { HydratedAutomodRuleDocument } from '@/models/automodRules';
 
 // TODO - This doesn't really belong here
 export function getInvalidPostRegex(): RegExp {
@@ -218,4 +222,56 @@ export function getValueFromHeaders(headers: IncomingHttpHeaders, key: string): 
 	}
 
 	return value;
+}
+
+export type AutomodRuleEvaluation = {
+	violatedRule: HydratedAutomodRuleDocument;
+	action: AutomodAction;
+} | null;
+
+export function evaluateAutomodRules(post: IPostInput, rules: HydratedAutomodRuleDocument[]): AutomodRuleEvaluation {
+	const blockRules = rules.filter(v => v.mode === 'block');
+	const nonBlockRules = rules.filter(v => v.mode !== 'block');
+	const orderedRules = [...blockRules, ...nonBlockRules];
+
+	for (const rule of orderedRules) {
+		let hasMatched = false;
+		if (rule.type === 'keyword') {
+			const bodyNormalized = (post.body ?? '').toLowerCase();
+			const keywordsToCheck = rule.keyword_settings?.keywords ?? [];
+			const matchedKeywords = keywordsToCheck.filter(keyword => bodyNormalized.includes(keyword.toLowerCase()));
+			hasMatched = matchedKeywords.length > 0;
+		}
+
+		if (hasMatched) {
+			return {
+				action: rule.mode === 'block' ? 'blocked' : 'logged',
+				violatedRule: rule
+			};
+		}
+	}
+
+	return null; // No rules apply to this post
+}
+
+export async function performAutomodAction(post: IPostInput, evaluation: AutomodRuleEvaluation): Promise<{ allowPost: boolean }> {
+	if (!evaluation) {
+		return { allowPost: true };
+	}
+
+	if (evaluation.action === 'blocked' || evaluation.action === 'logged') {
+		const allowPost = evaluation.action === 'blocked' ? false : true;
+		await AutomodLog.create({
+			action: evaluation.action,
+			post_id: post.id,
+			post_content_body: post.body ?? '',
+			created_at: new Date(),
+			rule_id: evaluation.violatedRule.id
+		});
+		return {
+			allowPost
+		};
+	}
+
+	throw new Error('Invalid automod evaluation');
 }

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -263,6 +263,7 @@ export async function performAutomodAction(post: IPostInput, evaluation: Automod
 		const allowPost = evaluation.action === 'blocked' ? false : true;
 		await AutomodLog.create({
 			action: evaluation.action,
+			author: post.pid,
 			post_id: post.id,
 			post_content_body: post.body ?? '',
 			created_at: new Date(),


### PR DESCRIPTION
Changes:
- Add automod rules and logs to db
  - two modes: log and block
  - one type: keyword (match by keywords)
  - can be disabled if needed
  - Has a title, and optionally a description for some extra context
- Add automod evaluation to posting flows
- Added a way to give user feedback when posting goes wrong, implemented for automod
- Added mod pages to view logs and rules (for moderators)
- Added mod pages to create/update/delete automod rules (for admins)

The html is incredibly janky and stupid, but I really cba to do CSS rn.

Resolves #20 
