### PR TITLE
More details for automod logs

### DIFF
--- a/apps/juxtaposition-ui/src/models/automodLog.ts
+++ b/apps/juxtaposition-ui/src/models/automodLog.ts
@@ -4,16 +4,35 @@ import type { HydratedDocument } from 'mongoose';
 export const automodAction = ['blocked', 'logged'] as const;
 export type AutomodAction = (typeof automodAction)[number];
 
+export type AutomodLogMatch = {
+	start: number;
+	end: number;
+} & Document;
+
 export type AutomodLog = {
 	rule_id: string;
 	created_at: Date;
 	author: number;
 	action: AutomodAction;
 	post_id: string | null;
+	parent_post_id: string | null;
+	community_id: string | null;
+	matches: AutomodLogMatch[] | null;
 	post_content_body: string | null;
 } & Document;
 
 export type HydratedAutomodLogDocument = HydratedDocument<AutomodLog>;
+
+export const automodLogMatchSchema = new Schema<AutomodLogMatch>({
+	start: {
+		type: Number,
+		required: true
+	},
+	end: {
+		type: Number,
+		required: true
+	}
+});
 
 export const automodLogSchema = new Schema<AutomodLog>({
 	rule_id: {
@@ -35,6 +54,18 @@ export const automodLogSchema = new Schema<AutomodLog>({
 	},
 	post_id: {
 		type: String,
+		required: false
+	},
+	parent_post_id: {
+		type: String,
+		required: false
+	},
+	community_id: {
+		type: String,
+		required: false
+	},
+	matches: {
+		type: [automodLogMatchSchema],
 		required: false
 	},
 	post_content_body: {

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
@@ -19,6 +19,42 @@ export type AutomodLogListViewProps = {
 	hasNextPage: boolean;
 };
 
+// Potentially the most complex rendering logic I've written in a while
+function LogBodyWithMatches({ log }: AutomodLogItemViewProps): ReactNode {
+	const body = log.postContent?.body;
+	const matches = log.matches;
+	if (!body) {
+		return 'NO BODY';
+	}
+
+	const orderedMatches = [...matches].sort((a, b) => a.start - b.start);
+	const noOverlapMatches = orderedMatches.map((v, i, arr) => {
+		if (arr.length === i + 1) {
+			return v;
+		} // Skip last item
+		const nextItem = arr[i + 1];
+		v.end = Math.min(v.end, nextItem.start); // Never overlap
+		return v;
+	});
+
+	let lastSplitEndIndex = 0;
+	const parts: ReactNode[] = [];
+	for (const match of noOverlapMatches) {
+		if (match.start > lastSplitEndIndex) {
+			parts.push(body.slice(lastSplitEndIndex, match.start)); // Anything in front of the match
+		}
+
+		const str = body.slice(match.start, match.end);
+		lastSplitEndIndex = match.end;
+		parts.push(<mark>{str}</mark>);
+	}
+	if (lastSplitEndIndex < body.length) {
+		parts.push(body.slice(lastSplitEndIndex)); // Anything in after last match
+	}
+
+	return parts;
+}
+
 function AutomodLogItem({ log }: AutomodLogItemViewProps): ReactNode {
 	const cache = useCache();
 
@@ -45,9 +81,7 @@ function AutomodLogItem({ log }: AutomodLogItemViewProps): ReactNode {
 					</span>
 					<span className="text">
 						<h4>Body:</h4>
-						<p>
-							{log.postContent?.body ?? 'NO BODY'}
-						</p>
+						<p><LogBodyWithMatches log={log} /></p>
 					</span>
 				</span>
 			</div>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/automodLogListView.tsx
@@ -86,6 +86,7 @@ function AutomodLogItem({ log }: AutomodLogItemViewProps): ReactNode {
 				</span>
 			</div>
 			<div className="button-spacer">
+				{ log.parentPostId ? <a href={`/posts/${log.parentPostId}`}>Go to parent post</a> : null }
 				{ log.postId ? <a href={`/posts/${log.postId}`}>Go to post</a> : null }
 			</div>
 		</li>

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -441,8 +441,13 @@ export async function passwordLogin(username: string, password: string): Promise
 // 	});
 // }
 
+export type AutomodRuleEvaluationMatch = {
+	start: number;
+	end: number;
+};
 export type AutomodRuleEvaluation = {
 	violatedRule: HydratedAutomodRuleDocument;
+	matches: AutomodRuleEvaluationMatch[];
 	action: AutomodAction;
 } | null;
 
@@ -453,16 +458,19 @@ export function evaluateAutomodRules(post: any, rules: HydratedAutomodRuleDocume
 
 	for (const rule of orderedRules) {
 		let hasMatched = false;
+		const matches: AutomodRuleEvaluationMatch[] = [];
 		if (rule.type === 'keyword') {
 			const bodyNormalized = (post.body ?? '').toLowerCase();
 			const keywordsToCheck = rule.keyword_settings?.keywords ?? [];
 			const matchedKeywords = keywordsToCheck.filter(keyword => bodyNormalized.includes(keyword.toLowerCase()));
 			hasMatched = matchedKeywords.length > 0;
+			// TODO add actual matching
 		}
 
 		if (hasMatched) {
 			return {
 				action: rule.mode === 'block' ? 'blocked' : 'logged',
+				matches,
 				violatedRule: rule
 			};
 		}
@@ -484,7 +492,13 @@ export async function performAutomodAction(post: any, evaluation: AutomodRuleEva
 			post_id: post.id,
 			post_content_body: post.body ?? '',
 			created_at: new Date(),
-			rule_id: evaluation.violatedRule.id
+			rule_id: evaluation.violatedRule.id,
+			parent_post_id: post.parent ?? null,
+			community_id: post.community_id,
+			matches: evaluation.matches.map(match => ({
+				start: match.start,
+				end: match.end
+			}))
 		});
 		return {
 			allowPost

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -460,11 +460,21 @@ export function evaluateAutomodRules(post: any, rules: HydratedAutomodRuleDocume
 		let hasMatched = false;
 		const matches: AutomodRuleEvaluationMatch[] = [];
 		if (rule.type === 'keyword') {
-			const bodyNormalized = (post.body ?? '').toLowerCase();
+			const bodyNormalized: string = (post.body ?? '').toLowerCase();
 			const keywordsToCheck = rule.keyword_settings?.keywords ?? [];
-			const matchedKeywords = keywordsToCheck.filter(keyword => bodyNormalized.includes(keyword.toLowerCase()));
-			hasMatched = matchedKeywords.length > 0;
-			// TODO add actual matching
+			keywordsToCheck.forEach((keywordUpper) => {
+				const keyword = keywordUpper.toLowerCase();
+				const index = bodyNormalized.indexOf(keyword);
+				if (index < 0) {
+					return;
+				}
+
+				hasMatched = true;
+				matches.push({
+					start: index,
+					end: index + keyword.length
+				});
+			});
 		}
 
 		if (hasMatched) {

--- a/apps/miiverse-api/src/models/automodLog.ts
+++ b/apps/miiverse-api/src/models/automodLog.ts
@@ -4,16 +4,35 @@ import type { HydratedDocument } from 'mongoose';
 export const automodAction = ['blocked', 'logged'] as const;
 export type AutomodAction = (typeof automodAction)[number];
 
+export type AutomodLogMatch = {
+	start: number;
+	end: number;
+} & Document;
+
 export type AutomodLog = {
 	rule_id: string;
 	created_at: Date;
 	author: number;
 	action: AutomodAction;
 	post_id: string | null;
+	parent_post_id: string | null;
+	community_id: string | null;
+	matches: AutomodLogMatch[] | null;
 	post_content_body: string | null;
 } & Document;
 
 export type HydratedAutomodLogDocument = HydratedDocument<AutomodLog>;
+
+export const automodLogMatchSchema = new Schema<AutomodLogMatch>({
+	start: {
+		type: Number,
+		required: true
+	},
+	end: {
+		type: Number,
+		required: true
+	}
+});
 
 export const automodLogSchema = new Schema<AutomodLog>({
 	rule_id: {
@@ -35,6 +54,18 @@ export const automodLogSchema = new Schema<AutomodLog>({
 	},
 	post_id: {
 		type: String,
+		required: false
+	},
+	parent_post_id: {
+		type: String,
+		required: false
+	},
+	community_id: {
+		type: String,
+		required: false
+	},
+	matches: {
+		type: [automodLogMatchSchema],
 		required: false
 	},
 	post_content_body: {

--- a/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/automodLog.ts
@@ -14,6 +14,12 @@ export const automodLogSchema = z.object({
 	action: automodActionEnum,
 	postAuthor: z.number(),
 	postId: z.string().nullable(),
+	parentPostId: z.string().nullable(),
+	communityId: z.string().nullable(),
+	matches: z.array(z.object({
+		start: z.number(),
+		end: z.number()
+	})),
 	postContent: z.object({
 		body: z.string().nullable()
 	})
@@ -29,6 +35,9 @@ export function mapAutomodLog(log: HydratedAutomodLogDocument, rule: HydratedAut
 		action: log.action,
 		postAuthor: log.author,
 		postId: log.action === 'blocked' ? null : log.post_id,
+		parentPostId: log.parent_post_id,
+		communityId: log.community_id,
+		matches: log.matches ?? [],
 		postContent: {
 			body: log.post_content_body
 		}

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -224,8 +224,13 @@ export function getValueFromHeaders(headers: IncomingHttpHeaders, key: string): 
 	return value;
 }
 
+export type AutomodRuleEvaluationMatch = {
+	start: number;
+	end: number;
+};
 export type AutomodRuleEvaluation = {
 	violatedRule: HydratedAutomodRuleDocument;
+	matches: AutomodRuleEvaluationMatch[];
 	action: AutomodAction;
 } | null;
 
@@ -236,16 +241,19 @@ export function evaluateAutomodRules(post: IPostInput, rules: HydratedAutomodRul
 
 	for (const rule of orderedRules) {
 		let hasMatched = false;
+		const matches: AutomodRuleEvaluationMatch[] = [];
 		if (rule.type === 'keyword') {
 			const bodyNormalized = (post.body ?? '').toLowerCase();
 			const keywordsToCheck = rule.keyword_settings?.keywords ?? [];
 			const matchedKeywords = keywordsToCheck.filter(keyword => bodyNormalized.includes(keyword.toLowerCase()));
 			hasMatched = matchedKeywords.length > 0;
+			// TODO add actual matching
 		}
 
 		if (hasMatched) {
 			return {
 				action: rule.mode === 'block' ? 'blocked' : 'logged',
+				matches,
 				violatedRule: rule
 			};
 		}
@@ -267,7 +275,13 @@ export async function performAutomodAction(post: IPostInput, evaluation: Automod
 			post_id: post.id,
 			post_content_body: post.body ?? '',
 			created_at: new Date(),
-			rule_id: evaluation.violatedRule.id
+			rule_id: evaluation.violatedRule.id,
+			parent_post_id: post.parent ?? null,
+			community_id: post.community_id,
+			matches: evaluation.matches.map(match => ({
+				start: match.start,
+				end: match.end
+			}))
 		});
 		return {
 			allowPost

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -245,9 +245,19 @@ export function evaluateAutomodRules(post: IPostInput, rules: HydratedAutomodRul
 		if (rule.type === 'keyword') {
 			const bodyNormalized = (post.body ?? '').toLowerCase();
 			const keywordsToCheck = rule.keyword_settings?.keywords ?? [];
-			const matchedKeywords = keywordsToCheck.filter(keyword => bodyNormalized.includes(keyword.toLowerCase()));
-			hasMatched = matchedKeywords.length > 0;
-			// TODO add actual matching
+			keywordsToCheck.forEach((keywordUpper) => {
+				const keyword = keywordUpper.toLowerCase();
+				const index = bodyNormalized.indexOf(keyword);
+				if (index < 0) {
+					return;
+				}
+
+				hasMatched = true;
+				matches.push({
+					start: index,
+					end: index + keyword.length
+				});
+			});
 		}
 
 		if (hasMatched) {


### PR DESCRIPTION
Changes:
- Add parent_post_id to automod logs - parent posts are sometimes high frequency logs, mods need to check them
- Add community_id to automod logs - Unused for now, but good data to have in the future
- Added matches to automod logs - a list of matches, to see what in the body was problematic
- Added button in frontend to go to the parent post
- Added highlighting of matches in automod logs (this was pretty complicated to write)

Resolves #496 

PS: cant wait for posting to be on only one project, then a lot of duplicated code can be removed :tada: