### PR TITLE
fix: "Poppins" font loads properly on Web

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderateUserView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderateUserView.tsx
@@ -148,7 +148,7 @@ export function WebModerateUserView(props: ModerateUserViewProps): ReactNode {
 						</div>
 					</summary>
 					<ul className="list-content-with-icon-and-text arrow-list">
-						{props.auditLog.length === 0 ? <h4>There's nothing here...</h4> : null}
+						{props.auditLog.length === 0 ? <p>There's nothing here...</p> : null}
 						{props.auditLog.map(log => (
 							<li className="reports">
 								<details>
@@ -189,7 +189,7 @@ export function WebModerateUserView(props: ModerateUserViewProps): ReactNode {
 						</div>
 					</summary>
 					<ul className="list-content-with-icon-and-text arrow-list">
-						{props.reports.length === 0 ? <h4>There's nothing here...</h4> : null}
+						{props.reports.length === 0 ? <p>There's nothing here...</p> : null}
 						{props.reports.map((report) => {
 							const post = props.postsMap.find(post => post.id === report.post_id);
 							return (
@@ -251,7 +251,7 @@ export function WebModerateUserView(props: ModerateUserViewProps): ReactNode {
 						</div>
 					</summary>
 					<ul className="list-content-with-icon-and-text arrow-list">
-						{props.submittedReports.length === 0 ? <h4>There's nothing here...</h4> : null}
+						{props.submittedReports.length === 0 ? <p>There's nothing here...</p> : null}
 						{props.submittedReports.map((report) => {
 							const post = props.postsMap.find(post => post.id === report.post_id);
 							return (
@@ -314,7 +314,7 @@ export function WebModerateUserView(props: ModerateUserViewProps): ReactNode {
 						</div>
 					</summary>
 					<ul className="list-content-with-icon-and-text arrow-list">
-						{props.removedPosts.length === 0 ? <h4>There's nothing here...</h4> : null}
+						{props.removedPosts.length === 0 ? <p>There's nothing here...</p> : null}
 						{props.removedPosts.map(post => (
 							<li className="reports">
 								<details>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/communityListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/communityListView.tsx
@@ -24,9 +24,9 @@ function WebCommunityItem(props: CommunityItemProps): ReactNode {
 		<a key={props.community.olive_community_id} className="community-list-wrapper" href={`/titles/${props.community.olive_community_id}/new`}>
 			<img className="community-list-icon" src={url.cdn(`/icons/${props.community.olive_community_id}/128.png`)} />
 			<h2 className="community-list-title">{props.community.name}</h2>
-			<h4 className="community-list-followers">
+			<p className="community-list-followers">
 				<T k="community.followers_count" values={{ count: props.community.followerCount }} />
-			</h4>
+			</p>
 		</a>
 	);
 }

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/post.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/post.tsx
@@ -73,11 +73,11 @@ export function WebPostView(props: PostViewProps): ReactNode {
 							)
 						: null}
 
-					<h4>
+					<p className="extra-info">
 						<a href={`/posts/${post.id}`}>{moment(post.created_at).fromNow()}</a>
 						{' - '}
 						<a href={`/titles/${post.community_id}`}>{cache.getCommunityName(post.community_id ?? '')}</a>
-					</h4>
+					</p>
 				</div>
 			</div>
 			{ post.is_spoiler
@@ -98,7 +98,7 @@ export function WebPostView(props: PostViewProps): ReactNode {
 				}}
 				evt-click={`location.href='/posts/${post.id}'`}
 			>
-				{post.body !== '' ? <h4>{post.body}</h4> : null}
+				{post.body !== '' ? <p>{post.body}</p> : null}
 				<WebPostScreenshot post={props.post}></WebPostScreenshot>
 				{post.painting !== '' ? <img id={post.id ?? undefined} className="painting" src={url.cdn(`/paintings/${post.pid}/${post.id}.png`)} /> : null}
 				{/* TODO add post.url back */}

--- a/apps/juxtaposition-ui/webfiles/web/css/web.css
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.css
@@ -71,7 +71,7 @@ button {
 body {
   background-color: var(--background);
   margin: 0;
-  font-family: Conv_Poppins-Light, sans-serif;
+  font-family: Poppins, sans-serif;
 }
 
 header {

--- a/apps/juxtaposition-ui/webfiles/web/css/web.css
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.css
@@ -12,6 +12,19 @@
   --background-alt-alt: #383f6b;
 }
 
+p {
+  margin: 0;
+}
+
+body, html {
+  line-height: 1.2;
+  -webkit-font-smoothing: antialiased;
+}
+
+button, input {
+  font-family: inherit;
+}
+
 button,
 input[type="button"],
 input[type="submit"] {
@@ -161,7 +174,7 @@ header > .selected svg {
   text-decoration: underline;
 }
 
-.post-meta-wrapper > h4:last-child {
+.post-meta-wrapper > .extra-info {
   padding-left: 0.5em;
   color: var(--text-secondary);
 }
@@ -230,7 +243,7 @@ header > .selected svg {
   cursor: pointer;
 }
 
-.post-content > h4 {
+.post-content > p {
   margin-top: 0;
   margin-bottom: 0.5em;
   font-weight: 400;
@@ -461,6 +474,10 @@ iframe {
   overflow: hidden;
 }
 
+.community-top h4 {
+  font-weight: normal;
+}
+
 .community-info {
   display: flex;
 }
@@ -567,6 +584,7 @@ iframe {
 #news-list-content li .text .pid-display {
   color: #969696;
   white-space: nowrap;
+  font-weight: normal;
 }
 
 .hover {

--- a/apps/juxtaposition-ui/webfiles/web/css/web.css
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.css
@@ -390,11 +390,11 @@ iframe {
 
 .community-list-title {
   margin: 0.5em 0-1em;
-  font-size: 2ch;
+  font-size: 18px;
 }
 
 .community-list-followers {
-  margin: 0.5em 0 0;
+  margin: 1em 0 0;
   font-size: 1.5ch;
 }
 


### PR DESCRIPTION
Resolves #500 

### Changes:

1. Edited the `web.css` file so the Poppins font displays properly.
2. Edited the `web.css` file to adjust a margin and font size slightly of two classes in the Community List after restoring the Poppins font.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.