### PR TITLE
Fix bugs introduced in datasource part 4

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/admin.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/admin/admin.tsx
@@ -130,14 +130,23 @@ adminRouter.post('/communities/new', upload.fields([{ name: 'browserIcon', maxCo
 		body: z.object({
 			has_shop_page: onOffBoolSchema,
 			is_recommended: onOffBoolSchema,
-			platform: z.string().trim(),
+			platform: z.coerce.number().pipe(z.enum({
+				wup: 0,
+				ctr: 1,
+				both: 2
+			})),
 			name: z.string().trim(),
 			description: z.string().trim(),
-			type: z.coerce.number(),
+			type: z.coerce.number().pipe(z.enum({
+				main: 0,
+				sub: 1,
+				announcement: 2,
+				private: 3
+			})),
 			parent: z.string().trim().nullable().transform(v => v === 'null' || v === '' ? null : v),
 			title_ids: zodCommaSeperatedList,
 			app_data: z.string().trim(),
-			shot_mode: z.string(),
+			shot_mode: z.enum(['allow', 'block', 'force']),
 			shot_extra_title_id: zodCommaSeperatedList
 		}),
 		files: ['browserIcon', 'CTRbrowserHeader', 'WiiUbrowserHeader']
@@ -150,17 +159,17 @@ adminRouter.post('/communities/new', upload.fields([{ name: 'browserIcon', maxCo
 	const { data: outputCommunity } = await req.api.admin.communities.create({
 		hasShopPage: body.has_shop_page,
 		isRecommended: body.is_recommended,
-		platform: body.platform as any,
+		platform: body.platform,
 		name: body.name,
 		description: body.description,
-		type: body.type as any,
+		type: body.type,
 		parent: body.parent,
 		titleIds: body.title_ids,
 		appData: body.app_data,
 		browserIcon: files.browserIcon[0].buffer.toString('base64'),
 		ctrBrowserHeader: files.CTRbrowserHeader[0].buffer.toString('base64'),
 		wiiuBrowserHeader: files.WiiUbrowserHeader[0].buffer.toString('base64'),
-		shotMode: body.shot_mode as any,
+		shotMode: body.shot_mode,
 		shotModeExtraTitleIds: body.shot_extra_title_id
 	});
 	updateCommunityHashForAdminCommunity(outputCommunity);
@@ -195,14 +204,23 @@ adminRouter.post('/communities/:id', upload.fields([{ name: 'browserIcon', maxCo
 		body: z.object({
 			has_shop_page: onOffBoolSchema,
 			is_recommended: onOffBoolSchema,
-			platform: z.string().trim(),
+			platform: z.coerce.number().pipe(z.enum({
+				wup: 0,
+				ctr: 1,
+				both: 2
+			})),
 			name: z.string().trim(),
 			description: z.string().trim(),
-			type: z.coerce.number(),
+			type: z.coerce.number().pipe(z.enum({
+				main: 0,
+				sub: 1,
+				announcement: 2,
+				private: 3
+			})),
 			parent: z.string().trim().nullable().transform(v => v === 'null' || v === '' ? null : v),
 			title_ids: zodCommaSeperatedList,
 			app_data: z.string().trim(),
-			shot_mode: z.string(),
+			shot_mode: z.enum(['allow', 'block', 'force']),
 			shot_extra_title_id: zodCommaSeperatedList
 		}),
 		files: ['browserIcon', 'CTRbrowserHeader', 'WiiUbrowserHeader']
@@ -213,17 +231,17 @@ adminRouter.post('/communities/:id', upload.fields([{ name: 'browserIcon', maxCo
 
 		hasShopPage: body.has_shop_page,
 		isRecommended: body.is_recommended,
-		platform: body.platform as any,
+		platform: body.platform,
 		name: body.name,
 		description: body.description,
-		type: body.type as any,
+		type: body.type,
 		parent: body.parent,
 		titleIds: body.title_ids,
 		appData: body.app_data,
 		browserIcon: files.browserIcon[0]?.buffer.toString('base64'),
 		ctrBrowserHeader: files.CTRbrowserHeader[0]?.buffer.toString('base64'),
 		wiiuBrowserHeader: files.WiiUbrowserHeader[0]?.buffer.toString('base64'),
-		shotMode: body.shot_mode as any,
+		shotMode: body.shot_mode,
 		shotModeExtraTitleIds: body.shot_extra_title_id
 	});
 

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderate-user/moderateUserPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderate-user/moderateUserPostView.tsx
@@ -33,10 +33,13 @@ export function ModerateUserRemovedPostView(props: ModerateUserRemovedPostsViewP
 									<span className="body messages report">
 										<span className="text">
 											<a href={`/users/${post.removed_by}`} className="nick-name">
-												Removed By:
+												{'Removed By: '}
 												{post.removed_by ? cache.getUserName(post.removed_by) : 'Nobody'}
 											</a>
-											<span title={moment(post.removed_at).toString()} className="timestamp">{moment(post.removed_at).fromNow()}</span>
+											<span title={moment(post.removed_at).toString()} className="timestamp">
+												{' '}
+												{moment(post.removed_at).fromNow()}
+											</span>
 										</span>
 										<span className="text">
 											<p>

--- a/apps/miiverse-api/src/services/internal/routes/admin/adminAuditLogs.ts
+++ b/apps/miiverse-api/src/services/internal/routes/admin/adminAuditLogs.ts
@@ -3,7 +3,7 @@ import { createInternalApiRouter } from '@/services/internal/builder/router';
 import { guards } from '@/services/internal/middleware/guards';
 import { mapPage, pageControlSchema, pageDtoSchema } from '@/services/internal/contract/page';
 import { Settings } from '@/models/settings';
-import { standardSortSchema } from '@/services/internal/contract/utils';
+import { standardSortSchema, standardSortToDirection } from '@/services/internal/contract/utils';
 import { auditLogActionSchema, auditLogSchema, mapAuditLog } from '@/services/internal/contract/admin/auditLogs';
 import { Logs } from '@/models/logs';
 import { deleteOptional } from '@/services/internal/utils';
@@ -31,6 +31,7 @@ adminAuditLogs.get({
 		});
 		const logs = await Logs
 			.find(dbQuery)
+			.sort({ timestamp: standardSortToDirection(query.sort) })
 			.limit(query.limit)
 			.skip(query.offset);
 		const total = await Logs.countDocuments(dbQuery);

--- a/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
+++ b/apps/miiverse-api/src/services/internal/routes/admin/adminAutomod.ts
@@ -103,7 +103,7 @@ adminAutomodRouter.patch({
 						}
 					: undefined
 			})
-		});
+		}, { new: true });
 
 		if (!rule) {
 			throw errors.for('not_found');

--- a/apps/miiverse-api/src/services/internal/routes/admin/adminCommunities.ts
+++ b/apps/miiverse-api/src/services/internal/routes/admin/adminCommunities.ts
@@ -262,7 +262,7 @@ adminCommunitiesRouter.patch({
 				shot_mode: body.shotMode,
 				shot_extra_title_id: body.shotModeExtraTitleIds
 			})
-		});
+		}, { new: true });
 		if (!comm) {
 			throw new Error('Can not find community after update');
 		}

--- a/apps/miiverse-api/src/services/internal/routes/admin/adminUsers.ts
+++ b/apps/miiverse-api/src/services/internal/routes/admin/adminUsers.ts
@@ -127,12 +127,14 @@ adminUsersRouter.patch({
 		if (body.accountStatus == 0) {
 			banLiftDate = null; // If account status is normal, remove ban date
 		}
-		const settings = await Settings.findOneAndUpdate({ pid: params.id }, deleteOptional({
-			account_status: body.accountStatus,
-			ban_lift_date: banLiftDate,
-			banned_by: account.pnid.pid,
-			ban_reason: body.banReason
-		}));
+		const settings = await Settings.findOneAndUpdate({ pid: params.id }, {
+			$set: deleteOptional({
+				account_status: body.accountStatus,
+				ban_lift_date: banLiftDate,
+				banned_by: account.pnid.pid,
+				ban_reason: body.banReason
+			})
+		}, { new: true });
 		if (!settings) {
 			throw new Error('Settings gone after save');
 		}

--- a/apps/miiverse-api/src/services/internal/server.ts
+++ b/apps/miiverse-api/src/services/internal/server.ts
@@ -16,7 +16,9 @@ import type { CallContext, ServerMiddlewareCall } from 'nice-grpc';
 // API server
 
 const app = express();
-app.use(express.json());
+app.use(express.json({
+	limit: '10mb' // File uploading
+}));
 app.use(loggerHttp);
 app.use(authPopulate);
 app.use(authAccessCheck);
@@ -33,6 +35,7 @@ app.use((err: Error, _request: express.Request, response: express.Response, next
 // Javascript error handler
 app.use((err: Error, _request: express.Request, response: express.Response, _next: express.NextFunction) => {
 	response.err = err; // For Pino
+	console.error(err);
 	response.status(500).json({ message: 'Internal server error' });
 });
 

--- a/apps/miiverse-api/src/services/internal/utils/search.ts
+++ b/apps/miiverse-api/src/services/internal/utils/search.ts
@@ -1,12 +1,23 @@
 import type { RootFilterQuery } from 'mongoose';
 
+function escapeRegexString(str: string): string {
+	// Everything not in this character set gets escaped
+	return str.replace(/[^\w\d\s]/g, c => '\\' + c);
+}
+
 export function buildSearchQuery<TDoc>(fields: Array<keyof TDoc>, keyword: string): RootFilterQuery<TDoc> {
-	const terms = keyword.trim().split(/\s+/);
+	const terms = keyword.trim().split(/\s+/).map(escapeRegexString);
 
 	return {
 		$or: fields.map(field => ({
 			$and: terms.map(term => ({
-				[field]: { $regex: term, $options: 'i' }
+				$expr: {
+					$regexMatch: {
+						input: { $toString: `$${String(field)}` },
+						regex: term,
+						options: 'i'
+					}
+				}
 			}))
 		}))
 	};


### PR DESCRIPTION
Fixes for bugs introduced in #482 

Changes:
 - fix: Fixed json body limit for internal API (higher limit required for file uploads)
 - fix: Added proper number fields for community platform+type
 - fix: Fixed searching util generating broken mongodb queries (now escaping symbols that could be regex-like)
 - fix: Added sort direction to audit log endpoint
 - fix: Fix findOneAndUpdate returning old document (and it being used for audit log changelog)
