### PR TITLE
Capitalization consistency and remove auto-open of reports Dropdown

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderate-user/moderateUserReportsView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderate-user/moderateUserReportsView.tsx
@@ -86,7 +86,7 @@ function ModerateUserReportView(props: ModerateUserReportProps): ReactNode {
 export function ModerateUserReportsListView(props: ModerateUserReportsListViewProps): ReactNode {
 	return (
 		<div>
-			<details open>
+			<details>
 				<summary>
 					<div className="mt-5">
 						<h4>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderate-user/moderateUserView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/moderate-user/moderateUserView.tsx
@@ -98,11 +98,11 @@ export function WebModerateUserView(props: ModerateUserViewProps): ReactNode {
 					</div>
 					<div className="info-boxes-wrapper">
 						<div>
-							<h4>Account status</h4>
+							<h4>Account Status</h4>
 							<h4>{profile.moderation.status}</h4>
 						</div>
 						<div>
-							<h4><a href={`/users/${profile.pid}`}>Go to profile</a></h4>
+							<h4><a href={`/users/${profile.pid}`}>Go to User Profile</a></h4>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
### changes:

this pr includes two main changes:
1. make consistent the capitalization on some of the newer moderator view labels with what was there prior
2. auto-collapse the dropdown of the "reports" tab now that it is no longer needed.

- [x] i have read and agreed to the [code of conduct](https://github.com/pretendonetwork/pretendo/blob/master/.github/code_of_conduct.md).
- [x] i have read and complied with the [contributing guidelines](https://github.com/pretendonetwork/pretendo/blob/master/.github/contributing.md).
- [ ] what i'm implementing was an [approved issue](../issues?q=is%3aopen+is%3aissue+label%3aapproved).
- [x] i have tested all of my changes.