### PR TITLE
Implement config for ratelimiting

### DIFF
--- a/apps/juxtaposition-ui/src/config.ts
+++ b/apps/juxtaposition-ui/src/config.ts
@@ -65,6 +65,10 @@ const schema = z.object({
 			apiKey: z.string()
 		})
 	}),
+	ratelimit: z.object({
+		yeahs: z.stringbool().default(true),
+		posts: z.stringbool().default(true)
+	}).prefault({}),
 	redis: z.object({
 		host: z.string(),
 		port: z.coerce.number().default(6379)
@@ -142,3 +146,5 @@ export const config = createConfig({
 	],
 	schema: flatZodSchema(schema)
 });
+
+export type Config = typeof config;

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/posts.tsx
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
 import express from 'express';
-import { rateLimit } from 'express-rate-limit';
 import multer from 'multer';
 import { z } from 'zod';
 import { config } from '@/config';
@@ -10,7 +9,7 @@ import { logger } from '@/logger';
 import { POST } from '@/models/post';
 import { REPORT } from '@/models/report';
 import { redisRemove } from '@/redisCache';
-import { evaluateAutomodRules, getInvalidPostRegex, getUserAccountData, performAutomodAction } from '@/util';
+import { createRatelimit, evaluateAutomodRules, getInvalidPostRegex, getUserAccountData, performAutomodAction } from '@/util';
 import { parseReq } from '@/services/juxt-web/routes/routeUtils';
 import { WebPostPageView } from '@/services/juxt-web/views/web/postPageView';
 import { CtrPostPageView } from '@/services/juxt-web/views/ctr/postPageView';
@@ -30,7 +29,7 @@ const storage = multer.memoryStorage();
 const upload = multer({ storage });
 export const postsRouter = express.Router();
 
-const postLimit = rateLimit({
+const postLimit = createRatelimit('posts', {
 	windowMs: 15 * 1000, // 30 seconds
 	max: 10, // Limit each IP to 1 request per `window`
 	standardHeaders: true,
@@ -50,7 +49,7 @@ const postLimit = rateLimit({
 	}
 });
 
-const yeahLimit = rateLimit({
+const yeahLimit = createRatelimit('yeahs', {
 	windowMs: 60 * 1000, // 1 minute
 	max: 60, // Limit each IP to 60 requests per `window`
 	standardHeaders: true,

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -10,6 +10,7 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
 import crc32 from 'crc/crc32';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
+import { rateLimit } from 'express-rate-limit';
 import { database } from '@/database';
 import { COMMUNITY } from '@/models/communities';
 import { logger } from '@/logger';
@@ -19,6 +20,7 @@ import { config } from '@/config';
 import { SystemType } from '@/types/common/system-types';
 import { TokenType } from '@/types/common/token-types';
 import { AutomodLog } from '@/models/automodLog';
+import type { Options as RatelimitOptions } from 'express-rate-limit';
 import type { ZodType } from 'zod';
 import type { ObjectCannedACL } from '@aws-sdk/client-s3';
 import type { InferSchemaType } from 'mongoose';
@@ -27,6 +29,8 @@ import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonet
 import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
 import type { LoginResponse } from '@pretendonetwork/grpc/api/login_rpc';
 import type { GetUserFriendPIDsResponse } from '@pretendonetwork/grpc/friends/get_user_friend_pids_rpc';
+import type { RequestHandler } from 'express';
+import type { Config } from '@/config';
 import type { ServiceToken } from '@/types/common/service-token';
 import type { ParamPack } from '@/types/common/param-pack';
 import type { CommunitySchema } from '@/models/communities';
@@ -498,4 +502,14 @@ export const langsFolder = path.join(distFolder, 'assets/locales');
 
 export function zodFallback<T>(value: T): ZodType<T> {
 	return z.any().transform(() => value);
+}
+
+export function createRatelimit(key: keyof Config['ratelimit'], ops: Partial<RatelimitOptions>): RequestHandler {
+	const rate = rateLimit(ops);
+	return (req, res, next) => {
+		if (config.ratelimit[key] === true) {
+			return rate(req, res, next);
+		}
+		return next();
+	};
 }


### PR DESCRIPTION
Changes:
- implement config option for toggling ratelimits on juxtaposition-ui

With this, we'll be able to disable ratelimits in prod for a while to diagnose any issues. And then turn it back on when we're done.