### PR TITLE
Fixed community list missing communities

### DIFF
--- a/apps/juxtaposition-ui/src/api/helpers.ts
+++ b/apps/juxtaposition-ui/src/api/helpers.ts
@@ -1,0 +1,31 @@
+export type AllFromListOptions = {
+	limit: number;
+};
+
+export type PageControls = {
+	limit: number;
+	offset: number;
+};
+
+export type PagedResponse<T> = {
+	items: Array<T>;
+	total: number;
+};
+
+export async function getAllFromList<TResponse extends { data: PagedResponse<any> }, T = TResponse['data']['items'][number]>(cb: (page: PageControls) => Promise<TResponse>, options: AllFromListOptions): Promise<T[]> {
+	const limit = options.limit;
+
+	const items: T[] = [];
+	let hasNextPage = true;
+	let offset = 0;
+	do {
+		const { data } = await cb({ offset, limit });
+		const page = data ?? { items: [], total: 0 }; // cb() is expected to throw on error, the fallback here should technically be unused
+
+		items.push(...page.items);
+		offset += limit;
+		hasNextPage = offset + limit < page.total;
+	} while (hasNextPage);
+
+	return items;
+}

--- a/apps/juxtaposition-ui/src/api/helpers.ts
+++ b/apps/juxtaposition-ui/src/api/helpers.ts
@@ -23,8 +23,8 @@ export async function getAllFromList<TResponse extends { data: PagedResponse<any
 		const page = data ?? { items: [], total: 0 }; // cb() is expected to throw on error, the fallback here should technically be unused
 
 		items.push(...page.items);
-		offset += limit;
 		hasNextPage = offset + limit < page.total;
+		offset += limit;
 	} while (hasNextPage);
 
 	return items;

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/communities.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/communities.tsx
@@ -20,6 +20,7 @@ import { CtrNewPostPage } from '@/services/juxt-web/views/ctr/newPostView';
 import { PortalNewPostPage } from '@/services/juxt-web/views/portal/newPostView';
 import { getShotMode, isPostingAllowed } from '@/services/juxt-web/routes/permissions';
 import { Community } from '@/models/communities';
+import { getAllFromList } from '@/api/helpers';
 import type { PostListViewProps } from '@/services/juxt-web/views/web/postList';
 import type { CommunityViewProps } from '@/services/juxt-web/views/web/communityView';
 import type { SubCommunityViewProps } from '@/services/juxt-web/views/portal/subCommunityView';
@@ -46,10 +47,10 @@ communitiesRouter.get('/', async function (req, res) {
 });
 
 communitiesRouter.get('/all', async function (req, res) {
-	const communities = await req.api.communities.list({ category: 'listed', limit: 90 });
+	const communities = await getAllFromList(page => req.api.communities.list({ ...page, category: 'listed' }), { limit: 90 });
 
 	const props: CommunityListViewProps = {
-		communities: communities.data.items
+		communities: communities
 	};
 	res.jsxForDirectory({
 		web: <WebCommunityListView {...props} />,


### PR DESCRIPTION
Changes:
- Added util to get all data from a paginated endpoint
- Used new util to get all communities on the "all communities" page

Resolves #511 
