### PR TITLE
hotfix(web): Make guest check reflect hasAuth() method

### DIFF
--- a/apps/juxtaposition-ui/src/middleware/webAuth.ts
+++ b/apps/juxtaposition-ui/src/middleware/webAuth.ts
@@ -45,7 +45,7 @@ export const webAuth: RequestHandler = async (request, response, next) => {
 	}
 
 	// Handle guest access pages
-	if (!request.pid) {
+	if (!request.pid || !request.user || !request.self) {
 		if (!requestOkForGuest(request)) {
 			return loginWall(request, response);
 		}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

**Hotfix:** This PR is against master, not dev!

### Changes:

We are receiving reports that users are seeing 404 screens and other issues when their tokens expire. The UI has a system where it extends token lifetimes by caching the user data blob in a cookie for read access, but the new API backend doesn't do this. This leads to weird behaviour when the UI thinks a user is logged in but the backend doesn't.
Fix this by adjusting the UI's guest access check to align with what the hasAuth() helper actually does. This will make users sign in again when the backend rejects their token.

This will mean that users don't get the benefit of the caching system and will have to log in hourly - this whole system desperately needs a refactor and refresh token auth, but I'm keeping the change minimal so we can hotfix it straight into prod and do a more proper tidy up later.

Same commit is available against dev in the `patch/guest-access` branch if that is preferable.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.