### PR TITLE
fix(web): Use WebCommunityIcon everywhere, improve community grid

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,4 +23,7 @@
     "[typescriptreact]": {
         "editor.defaultFormatter": "dbaeumer.vscode-eslint"
     },
+    "[scss]": {
+        "editor.defaultFormatter": "vscode.css-language-features"
+    },
 }

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/console/userpage.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/console/userpage.tsx
@@ -18,11 +18,11 @@ import { PortalUserMissingPage, PortalUserPageView } from '@/services/juxt-web/v
 import { CtrUserMissingPage, CtrUserPageView } from '@/services/juxt-web/views/ctr/userPageView';
 import { wrapApi } from '@/api/errors';
 import type { Request, Response } from 'express';
-import type { CommunityViewData, UserPageFollowingViewProps } from '@/services/juxt-web/views/web/userPageFollowingView';
+import type { UserPageFollowingViewProps } from '@/services/juxt-web/views/web/userPageFollowingView';
 import type { PostListViewProps } from '@/services/juxt-web/views/web/postList';
 import type { UserMissingPageViewProps, UserPageViewProps } from '@/services/juxt-web/views/web/userPageView';
 import type { UserSettingsViewProps } from '@/services/juxt-web/views/web/userSettingsView';
-import type { ShallowUser } from '@/api/generated';
+import type { Community, ShallowUser } from '@/api/generated';
 export const userPageRouter = express.Router();
 const upload = multer({ dest: 'uploads/' });
 
@@ -316,7 +316,7 @@ async function userRelations(req: Request, res: Response, userID: number): Promi
 	const link = isSelf ? '/users/me/' : `/users/${userID}/`;
 
 	let followers: ShallowUser[] = [];
-	let communities: CommunityViewData[] = [];
+	let communities: Community[] = [];
 	let selection = 0;
 
 	if (params.type === 'yeahs') {
@@ -371,7 +371,7 @@ async function userRelations(req: Request, res: Response, userID: number): Promi
 		const { data: page } = await req.api.users.listFollowing({ id: userID, limit: 100, offset });
 		const { data: communityPage } = await req.api.users.listFollowedCommunities({ id: userID, limit: 100, offset });
 		followers = page.items;
-		communities = communityPage.items.map(com => ({ id: com.olive_community_id, name: com.name }));
+		communities = communityPage.items;
 		selection = 2;
 	}
 

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/manageCommunityView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/manageCommunityView.tsx
@@ -3,6 +3,7 @@ import { WebNavBar } from '@/services/juxt-web/views/web/navbar';
 import { WebModerationTabs } from '@/services/juxt-web/views/web/admin/admin';
 import { useUrl } from '@/services/juxt-web/views/common/hooks/useUrl';
 import { WebSearchBar } from '@/services/juxt-web/views/web/components/ui/WebSearchBar';
+import { WebCommunityIcon } from '@/services/juxt-web/views/web/components/ui/WebCommunityIcon';
 import type { ReactNode } from 'react';
 import type { AdminCommunity } from '@/api/generated';
 
@@ -38,14 +39,14 @@ export function WebManageCommunityView(props: ManageCommunityViewProps): ReactNo
 								<ul className="list-content-with-icon-and-text arrow-list accounts" id="news-list-content">
 									{props.communities.map(community => (
 										<li key={community.id}>
-											<div className="hover">
-												<a href={`/communities/${community.olive_community_id}`} className="icon-container notify">
-													<img src={url.cdn(`/icons/${community.olive_community_id}/128.png`)} className="icon" />
-												</a>
-												<a className="body" href={`/communities/${community.olive_community_id}`}>
-													<span className="text"><span className="nick-name">{community.name}</span></span>
-												</a>
-											</div>
+											<a className="hover" href={`/communities/${community.olive_community_id}`}>
+												<WebCommunityIcon community={community} size="64" />
+												<div className="body">
+													<span className="text">
+														<span className="nick-name">{community.name}</span>
+													</span>
+												</div>
+											</a>
 											<button evt-click="this.children[0].click()"><a id={`account-${community.id}`} href={`/admin/communities/${community.olive_community_id}`}>Manage Community</a></button>
 										</li>
 									))}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/communityListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/communityListView.tsx
@@ -1,7 +1,7 @@
 import { WebRoot, WebWrapper } from '@/services/juxt-web/views/web/root';
 import { WebNavBar } from '@/services/juxt-web/views/web/navbar';
-import { useUrl } from '@/services/juxt-web/views/common/hooks/useUrl';
 import { T } from '@/services/juxt-web/views/common/components/T';
+import { WebCommunityIcon } from '@/services/juxt-web/views/web/components/ui/WebCommunityIcon';
 import type { ReactNode } from 'react';
 import type { Community } from '@/api/generated';
 
@@ -19,14 +19,15 @@ export type CommunityItemProps = {
 };
 
 export function WebCommunityItem(props: CommunityItemProps): ReactNode {
-	const url = useUrl();
 	return (
 		<a key={props.community.olive_community_id} className="community-list-wrapper" href={`/titles/${props.community.olive_community_id}/new`}>
-			<img className="community-list-icon" src={url.cdn(`/icons/${props.community.olive_community_id}/128.png`)} />
-			<h2 className="community-list-title">{props.community.name}</h2>
-			<p className="community-list-followers">
-				<T k="community.followers_count" values={{ count: props.community.followerCount }} />
-			</p>
+			<WebCommunityIcon type="community-list-icon" community={props.community} size="128" />
+			<div className="community-list-info">
+				<h2 className="community-list-title">{props.community.name}</h2>
+				<p className="community-list-followers">
+					<T k="community.followers_count" values={{ count: props.community.followerCount }} />
+				</p>
+			</div>
 		</a>
 	);
 }

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/communityView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/communityView.tsx
@@ -22,11 +22,10 @@ export type CommunityViewProps = {
 };
 
 export function WebCommunityHead(props: CommunityViewProps): ReactNode {
-	const url = useUrl();
 	const name = props.community.name;
 	const title = `Juxt - ${name}`;
 	const description = props.community.description;
-	const image = url.cdn(`/icons/${props.community.olive_community_id}/128.png`);
+	const image = props.community.iconImagePaths['128'];
 	const communityUrl = `https://juxt.pretendo.cc/communities/${props.community.olive_community_id}/new`;
 
 	return (

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebCommunityIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebCommunityIcon.tsx
@@ -1,13 +1,14 @@
 import { WebIcon } from '@/services/juxt-web/views/web/components/ui/WebIcon';
 import { useUrl } from '@/services/juxt-web/views/common/hooks/useUrl';
 import type { ReactNode } from 'react';
+import type { IconProps } from '@/services/juxt-web/views/web/components/ui/WebIcon';
 import type { Community } from '@/api/generated';
 
 export type CommunityIconProps = {
 	community: Community;
 	size: `${keyof Community['iconImagePaths']}`;
 	className?: string;
-	type?: 'header-icon' | 'icon'; // default icon
+	type?: IconProps['type'];
 };
 
 export function WebCommunityIcon(props: CommunityIconProps): ReactNode {

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebIcon.tsx
@@ -5,7 +5,7 @@ export type IconProps = {
 	src: string;
 	href?: string;
 
-	type?: 'icon' | 'mii-icon' | 'header-icon'; // default ".icon"
+	type?: 'icon' | 'mii-icon' | 'header-icon' | 'community-list-icon'; // default ".icon"
 	className?: string; // extra classes
 };
 

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebMiiIcon.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/ui/WebMiiIcon.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from 'react';
 export type MiiIconProps = {
 	pid: number;
 	face_url?: string;
+	link?: boolean; // default true
 
 	type?: 'mii-icon' | 'icon' | 'header-icon'; // default ".mii-icon"
 	className?: string; // extra classes
@@ -13,7 +14,7 @@ export type MiiIconProps = {
 export function WebMiiIcon(props: MiiIconProps): ReactNode {
 	const url = useUrl();
 	const miiUrl = props.face_url ?? url.cdn(`/mii/${props.pid}/normal_face.png`);
-	const href = `/users/${props.pid}`;
+	const href = props.link !== false ? `/users/${props.pid}` : undefined;
 	const type = props.type ?? 'mii-icon';
 
 	return (

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageFollowingView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageFollowingView.tsx
@@ -1,43 +1,39 @@
-import { useUrl } from '@/services/juxt-web/views/common/hooks/useUrl';
+import { WebCommunityIcon } from '@/services/juxt-web/views/web/components/ui/WebCommunityIcon';
+import { WebMiiIcon } from '@/services/juxt-web/views/web/components/ui/WebMiiIcon';
 import type { ReactNode } from 'react';
-import type { ShallowUser } from '@/api/generated';
-
-export type CommunityViewData = {
-	id: string;
-	name: string;
-};
+import type { Community, ShallowUser } from '@/api/generated';
 
 export type UserPageFollowingViewProps = {
 	followers: ShallowUser[];
-	communities: CommunityViewData[];
+	communities: Community[];
 };
 
 export function WebUserPageFollowingView(props: UserPageFollowingViewProps): ReactNode {
-	const url = useUrl();
 	return (
 		<ul className="list-content-with-icon-and-text arrow-list accounts" id="news-list-content">
 			{props.followers.map(user => (
 				<li key={user.pid} id={user.pid.toString()}>
-					<div className="hover">
-						<a href={`/users/${user.pid}`} className="icon-container notify">
-							<img src={url.cdn(`/mii/${user.pid}/normal_face.png`)} className="icon" />
-						</a>
-						<a className="body" href={`/users/${user.pid}`}>
-							<span className="text"><span className="nick-name">{user.miiName}</span></span>
-						</a>
-					</div>
+					<a className="hover" href={`/users/${user.pid}`}>
+						<WebMiiIcon pid={user.pid} type="icon" link={false} />
+						{/* TODO rebuild the CSS here so we can remove the duplication */}
+						<div className="body">
+							<span className="text">
+								<span className="nick-name">{user.miiName}</span>
+							</span>
+						</div>
+					</a>
 				</li>
 			))}
 			{props.communities.map(community => (
 				<li key={community.id} id={community.id}>
-					<div className="hover">
-						<a href={`/titles/${community.id}/new`} className="icon-container notify">
-							<img src={url.cdn(`/icons/${community.id}/128.png`)} className="icon" />
-						</a>
-						<a className="body" href={`/titles/${community.id}/new`}>
-							<span className="text"><span className="nick-name">{community.name}</span></span>
-						</a>
-					</div>
+					<a className="hover" href={`/titles/${community.olive_community_id}/new`}>
+						<WebCommunityIcon community={community} size="64" />
+						<div className="body">
+							<span className="text">
+								<span className="nick-name">{community.name}</span>
+							</span>
+						</div>
+					</a>
 				</li>
 			))}
 		</ul>

--- a/apps/juxtaposition-ui/webfiles/web/css/components/WebCommunityListView.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/components/WebCommunityListView.scss
@@ -1,0 +1,33 @@
+// Actually the wrapper for each individual community *in* the list
+.community-list-wrapper {
+    display: flex;
+
+    background: var(--background-alt);
+    padding: 1em;
+    border-radius: 1em;
+}
+
+.community-list-icon {
+    width: 100px;
+    height: 100px;
+
+    margin-right: 1em;
+    border-radius: 1em;
+    display: block;
+}
+
+.community-list-info {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    word-break: break-word;
+}
+
+.community-list-title {
+    font-size: 18px;
+    margin: 0; // since it's an h3
+}
+
+.community-list-followers {
+    font-size: 1.5ch;
+}

--- a/apps/juxtaposition-ui/webfiles/web/css/web.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.scss
@@ -1,5 +1,6 @@
 @use './theme.scss' as t;
 @use './components/WebInfobox.scss';
+@use './components/WebCommunityListView.scss';
 
 :root {
   --background: #1b1f3b;
@@ -418,44 +419,10 @@ iframe {
   transform: translateY(-130%);
 }
 
-.community-list-wrapper {
-  display: grid;
-  grid-template-areas: "icon main" "icon footer";
-  gap: 0;
-  cursor: pointer;
-  background: var(--background-alt);
-  padding: 1em;
-  width: 90%;
-  border-radius: 1em;
-  grid-template-columns: 111px 152px;
-}
-
-.community-list-icon {
-  width: 100px;
-  height: 100px;
-  grid-area: icon;
-  margin-right: 1em;
-  border-radius: 1em;
-  -webkit-border-radius: 1em;
-  -moz-border-radius: 1em;
-  -ms-border-radius: 1em;
-  -o-border-radius: 1em;
-}
-
-.community-list-title {
-  margin: 0.5em 0 -1em;
-  font-size: 18px;
-}
-
-.community-list-followers {
-  margin: 1em 0 0;
-  font-size: 1.5ch;
-}
-
 .communities-wrapper {
   display: grid;
   max-width: 900px;
-  grid-template-columns: auto auto auto;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   grid-row-gap: 1em;
   grid-column-gap: 1em;
 }
@@ -1451,7 +1418,7 @@ li.reports .button-spacer {
 @include t.media(">=tablet", "<desktop") {
   .communities-wrapper {
     max-width: 600px;
-    grid-template-columns: auto auto;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     grid-row-gap: 10px;
     grid-column-gap: 10px;
   }
@@ -1585,7 +1552,7 @@ li.reports .button-spacer {
 
   .communities-wrapper {
     max-width: 600px;
-    grid-template-columns: auto;
+    grid-template-columns: minmax(0, 1fr);
     grid-row-gap: 10px;
     grid-column-gap: 10px;
   }
@@ -1872,7 +1839,7 @@ button.report {
 @include t.media(">=tablet", "<desktop") {
 	.communities-wrapper {
 		max-width: 600px;
-		grid-template-columns: auto auto;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
 		grid-row-gap: 10px;
 		grid-column-gap: 10px
 	}
@@ -2006,7 +1973,7 @@ button.report {
 
 	.communities-wrapper {
 		max-width: 600px;
-		grid-template-columns: auto;
+		grid-template-columns: minmax(0, 1fr);
 		grid-row-gap: 10px;
 		grid-column-gap: 10px
 	}


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

After #410 landed, the API has been very kindly finding a valid icon for communities, even ones that don't have native ones (-> some subcommunities). This change ports all community icons in web to use the WebCommunityIcon component, which automatically pulls that data. This means those communities have their correct icons displayed. This is particularly noticeable in the new Related Communities view.

As usual in Juxt Web, touching something made the layout explode, so I also redid the elements in the community grid to use flexbox, and various list views to use one big anchor tag rather than lots of small ones. I had to keep the div structure the same in the latter though to avoid breaking the CSS - the whole list component needs to be rebuilt, but the goal of this PR was just to fix up the Related Communities view.

CommunityViewData had to go due to not including the icon fields, though since the caller was fetching the full community object anyway it's no great loss. 

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.