### PR TITLE
chore: Add Spacing between Post Links on Automod Logs

### DIFF
--- a/apps/juxtaposition-ui/webfiles/web/css/web.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.scss
@@ -1361,7 +1361,10 @@ li.reports .post-buttons-wrapper {
 li.reports .button-spacer {
   display: flex;
   justify-content: center;
-  column-gap: 16px;
+  text-align: center;
+  flex-wrap: wrap;
+  column-gap: 1rem;
+  row-gap: 1rem;
 }
 
 .accounts .hover {

--- a/apps/juxtaposition-ui/webfiles/web/css/web.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.scss
@@ -1359,7 +1359,9 @@ li.reports .post-buttons-wrapper {
 }
 
 li.reports .button-spacer {
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  column-gap: 16px;
 }
 
 .accounts .hover {


### PR DESCRIPTION
Resolves #526 

### Changes:

Added a gap between the two links by changing the container to flex and adding a column-gap.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.