### PR TITLE
Feat add account age

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/WebInfobox.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/WebInfobox.tsx
@@ -80,7 +80,7 @@ export function WebInfoboxStatBoxes(props: WebInfoboxStatBoxesProps): ReactNode 
 	return (
 		<div className={cx('stat-boxes', {
 			'cols-2': even && itemCount % 3 != 0,
-			'cols-3': !even || itemCount % 3 == 0,
+			'cols-3': !even || itemCount % 3 == 0
 		})}
 		>
 			{props.children}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/WebInfobox.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/components/WebInfobox.tsx
@@ -79,8 +79,8 @@ export function WebInfoboxStatBoxes(props: WebInfoboxStatBoxesProps): ReactNode 
 	const even = itemCount % 2 == 0;
 	return (
 		<div className={cx('stat-boxes', {
-			'cols-2': even,
-			'cols-3': !even
+			'cols-2': even && itemCount % 3 != 0,
+			'cols-3': !even || itemCount % 3 == 0,
 		})}
 		>
 			{props.children}

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
@@ -12,6 +12,7 @@ import { WebMiiIcon } from '@/services/juxt-web/views/web/components/ui/WebMiiIc
 import { WebIcon } from '@/services/juxt-web/views/web/components/ui/WebIcon';
 import type { ReactNode } from 'react';
 import type { SelfContent, UserBadgeEnum, UserProfile } from '@/api/generated';
+import { humanFromNow } from '@/util';
 
 export type UserMissingPageViewProps = {
 	pid: number;
@@ -161,6 +162,8 @@ export function WebUserPageView(props: UserPageViewProps): ReactNode {
 	const user = useUser();
 	const profile = props.profile;
 	const isSelf = user.pid === props.profile.pid;
+	const dateTime = new Date();
+	const accountAge = moment(dateTime).diff(moment(profile.createdAt), 'days');
 
 	const isRequesterFollowingUser = props.requestUserContent?.followed_users.includes(profile.pid) ?? false;
 
@@ -236,6 +239,14 @@ export function WebUserPageView(props: UserPageViewProps): ReactNode {
 						<div>
 							<div className="value" id="followers">{profile.followers}</div>
 							<div className="name"><T k="user_page.followers" /></div>
+						</div>
+						<div>
+							<div className="value" id="profileAge">{humanFromNow(profile.createdAt)}</div>
+							<div className="name">Account Age</div>
+						</div>
+						<div>
+							<div className="value" id="joinDate">{moment(profile.createdAt).format('MMM Do YY')}</div>
+							<div className="name">Join Date</div>
 						</div>
 					</WebInfoboxStatBoxes>
 				</WebInfobox>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/userPageView.tsx
@@ -10,9 +10,9 @@ import { WebUIIcon } from '@/services/juxt-web/views/web/components/ui/WebUIIcon
 import { WebInfobox, WebInfoboxButton, WebInfoboxButtons, WebInfoboxFollowButton, WebInfoboxStatBoxes } from '@/services/juxt-web/views/web/components/WebInfobox';
 import { WebMiiIcon } from '@/services/juxt-web/views/web/components/ui/WebMiiIcon';
 import { WebIcon } from '@/services/juxt-web/views/web/components/ui/WebIcon';
+import { humanFromNow } from '@/util';
 import type { ReactNode } from 'react';
 import type { SelfContent, UserBadgeEnum, UserProfile } from '@/api/generated';
-import { humanFromNow } from '@/util';
 
 export type UserMissingPageViewProps = {
 	pid: number;
@@ -162,8 +162,6 @@ export function WebUserPageView(props: UserPageViewProps): ReactNode {
 	const user = useUser();
 	const profile = props.profile;
 	const isSelf = user.pid === props.profile.pid;
-	const dateTime = new Date();
-	const accountAge = moment(dateTime).diff(moment(profile.createdAt), 'days');
 
 	const isRequesterFollowingUser = props.requestUserContent?.followed_users.includes(profile.pid) ?? false;
 

--- a/apps/miiverse-api/src/services/internal/contract/user.ts
+++ b/apps/miiverse-api/src/services/internal/contract/user.ts
@@ -32,6 +32,7 @@ export const userProfileSchema = asOpenapi('UserProfile', z.object({
 	followers: z.number(),
 	posts: z.number(),
 	isOnline: z.boolean(),
+	createdAt: z.date(),
 	profileInfo: z.object({
 		country: z.string().nullable(),
 		birthday: z.date().nullable(),
@@ -88,6 +89,7 @@ export function mapUserProfile(settings: HydratedSettingsDocument, pnid: GetUser
 		miiName: settings.screen_name,
 		flags: getProfileFlags(pnid),
 		isOnline: settings.last_active ? isDateInRange(settings.last_active, 10) : false,
+		createdAt: settings.created_at,
 		profileInfo: {
 			comment: settings.profile_comment_visibility ? settings.profile_comment ?? null : null,
 			country: settings.country_visibility ? pnid.country : null,


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #319 

### Changes:

Added two attributes to the user page on juxtaposition that displays the accounts age in days, and displays when the user joined the platform, to be added is a badge that displays next to the user's username when the user's account is less than a week old, and better formatting for the UI that displays the users information.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [x] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.