### PR TITLE
Chore(Web): Make Avatar Backgrounds/Borders Consistent

### DIFF
--- a/apps/juxtaposition-ui/webfiles/web/css/components/WebInfobox.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/components/WebInfobox.scss
@@ -35,8 +35,7 @@ $icon-size: 64px;
             display: flex;
         }
         .header-icon {
-            background: white;
-            border: 5px solid white;
+            background: var(--text-secondary);
             border-radius: t.$component-radius;
             width: $icon-size + 10px;
             height: $icon-size + 10px;

--- a/apps/juxtaposition-ui/webfiles/web/css/web.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.scss
@@ -263,10 +263,7 @@ header>.selected svg {
 }
 
 .user-icon.verified {
-  box-sizing: border-box;
   border: solid 4px var(--btn);
-  width: 64px;
-  height: 64px;
 }
 
 .verified-badge {

--- a/apps/juxtaposition-ui/webfiles/web/css/web.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.scss
@@ -254,6 +254,7 @@ header>.selected svg {
 
 .icon-container>img,
 .user-icon {
+  box-sizing: border-box;
   width: 64px;
   height: 64px;
   border-radius: 0.5em;
@@ -262,9 +263,10 @@ header>.selected svg {
 }
 
 .user-icon.verified {
+  box-sizing: border-box;
   border: solid 4px var(--btn);
-  width: 60px;
-  height: 60px;
+  width: 64px;
+  height: 64px;
 }
 
 .verified-badge {


### PR DESCRIPTION
Resolves #541 

### Changes:

1. The Header Avatar background and border matches the user's Post Avatar on their user page

2. Also included is a small change in the structure of these elements box-sizing (changing them to `border-box`) so, in the future, if we change more about them, it won't affect the surrounding elements' styling.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.