### PR TITLE
Allow upload of BMP images

### DIFF
--- a/apps/juxtaposition-ui/src/images.ts
+++ b/apps/juxtaposition-ui/src/images.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
-import { AlphaOption, ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColors, Orientation } from '@imagemagick/magick-wasm';
+import { AlphaAction, ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColor, MagickColors, Orientation } from '@imagemagick/magick-wasm';
 import { deflate, inflate } from 'pako';
 import { logger } from '@/logger';
 import { uploadCDNAsset } from '@/util';
@@ -182,8 +182,8 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 	image.settings.interlace = Interlace.Jpeg;
 
 	// Remove alpha if input was an alpha-enabled BMP
-	image.backgroundColor = 'white';
-	image.alpha(AlphaOption.Remove);
+	image.backgroundColor = new MagickColor('white');
+	image.alpha(AlphaAction.Remove);
 
 	return {
 		jpg: image.write('JPEG', Buffer.from),
@@ -212,31 +212,16 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 }
 
 export function processAutoScreenshot(screenshot: Buffer): Screenshot | null {
-	let format: 'JPG' | 'BMP';
-
-	// JPEG: FF D8 FF
-	// Used by official Miiverse-enabled games
-	if (
-		screenshot.length >= 3 &&
-		screenshot[0] === 0xff &&
-		screenshot[1] === 0xd8 &&
-		screenshot[2] === 0xff
-	) {
-		format = 'JPG';
-	}
-	// BMP: 42 4D ("BM")
-	// Used by un-official mods, such as CTGP-7
-	else if (
-		screenshot.length >= 2 &&
-		screenshot[0] === 0x42 &&
-		screenshot[1] === 0x4d
-	) {
-		format = 'BMP';
-	} else {
-		return null;
-	}
-
-	return ImageMagick.read(screenshot, format, processScreenshot);
+	const allowedFormats = [
+		'JPEG', // Used by Miiverse and Miiverse-enabled games
+		'BMP' // Used by un-official mods, such as CTGP-7
+	];
+	return ImageMagick.read(screenshot, (img) => {
+		if (!allowedFormats.includes(img.format)) {
+			throw new Error(`Invalid format, got '${img.format}'`);
+		}
+		return processScreenshot(img);
+	});
 }
 
 export type ScreenshotUrls = {

--- a/apps/juxtaposition-ui/src/images.ts
+++ b/apps/juxtaposition-ui/src/images.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
-import { ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColors, Orientation } from '@imagemagick/magick-wasm';
+import { AlphaOption, ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColors, Orientation } from '@imagemagick/magick-wasm';
 import { deflate, inflate } from 'pako';
 import { logger } from '@/logger';
 import { uploadCDNAsset } from '@/util';
@@ -181,6 +181,10 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 	image.settings.setDefine('JPEG', 'sampling-factor', '2x2');
 	image.settings.interlace = Interlace.Jpeg;
 
+	// Remove alpha if input was an alpha-enabled BMP
+	image.backgroundColor = 'white';
+	image.alpha(AlphaOption.Remove);
+
 	return {
 		jpg: image.write('JPEG', Buffer.from),
 		thumb: image.clone((image) => {
@@ -207,8 +211,32 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 	};
 }
 
-export function processJpgScreenshot(painting: Buffer): Screenshot | null {
-	return ImageMagick.read(painting, 'JPG', processScreenshot);
+export function processAutoScreenshot(screenshot: Buffer): Screenshot | null {
+	let format: 'JPG' | 'BMP';
+
+	// JPEG: FF D8 FF
+	// Used by official Miiverse-enabled games
+	if (
+		screenshot.length >= 3 &&
+		screenshot[0] === 0xff &&
+		screenshot[1] === 0xd8 &&
+		screenshot[2] === 0xff
+	) {
+		format = 'JPG';
+	}
+	// BMP: 42 4D ("BM")
+	// Used by un-official mods, such as CTGP-7
+	else if (
+		screenshot.length >= 2 &&
+		screenshot[0] === 0x42 &&
+		screenshot[1] === 0x4d
+	) {
+		format = 'BMP';
+	} else {
+		return null;
+	}
+
+	return ImageMagick.read(screenshot, format, processScreenshot);
 }
 
 export type ScreenshotUrls = {
@@ -228,7 +256,7 @@ export type UploadScreenshotOptions = {
 export async function uploadScreenshot(opts: UploadScreenshotOptions): Promise<ScreenshotUrls | null> {
 	// try buffer, otherwise blob
 	const screenshotBuf = opts.buffer ?? Buffer.from(opts.blob.replace(/\0/g, '').trim(), 'base64');
-	const screenshots = processJpgScreenshot(screenshotBuf);
+	const screenshots = processAutoScreenshot(screenshotBuf);
 	if (screenshots === null) {
 		return null;
 	}

--- a/apps/juxtaposition-ui/src/images.ts
+++ b/apps/juxtaposition-ui/src/images.ts
@@ -214,7 +214,7 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 export function processAutoScreenshot(screenshot: Buffer): Screenshot | null {
 	const allowedFormats = [
 		'JPEG', // Used by Miiverse and Miiverse-enabled games
-		'BMP' // Used by un-official mods, such as CTGP-7
+		'BMP', 'BMP3' // Used by un-official mods, such as CTGP-7
 	];
 	return ImageMagick.read(screenshot, (img) => {
 		if (!allowedFormats.includes(img.format)) {

--- a/apps/miiverse-api/src/images.ts
+++ b/apps/miiverse-api/src/images.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
-import { AlphaOption, ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColors, Orientation } from '@imagemagick/magick-wasm';
+import { AlphaAction, ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColor, MagickColors, Orientation } from '@imagemagick/magick-wasm';
 import { deflate, inflate } from 'pako';
 import { logger } from '@/logger';
 import { uploadCDNAsset } from '@/util';
@@ -182,8 +182,8 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 	image.settings.interlace = Interlace.Jpeg;
 
 	// Remove alpha if input was an alpha-enabled BMP
-	image.backgroundColor = 'white';
-	image.alpha(AlphaOption.Remove);
+	image.backgroundColor = new MagickColor('white');
+	image.alpha(AlphaAction.Remove);
 
 	return {
 		jpg: image.write('JPEG', Buffer.from),
@@ -212,31 +212,16 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 }
 
 export function processAutoScreenshot(screenshot: Buffer): Screenshot | null {
-	let format: 'JPG' | 'BMP';
-
-	// JPEG: FF D8 FF
-	// Used by official Miiverse-enabled games
-	if (
-		screenshot.length >= 3 &&
-		screenshot[0] === 0xff &&
-		screenshot[1] === 0xd8 &&
-		screenshot[2] === 0xff
-	) {
-		format = 'JPG';
-	}
-	// BMP: 42 4D ("BM")
-	// Used by un-official mods, such as CTGP-7
-	else if (
-		screenshot.length >= 2 &&
-		screenshot[0] === 0x42 &&
-		screenshot[1] === 0x4d
-	) {
-		format = 'BMP';
-	} else {
-		return null;
-	}
-
-	return ImageMagick.read(screenshot, format, processScreenshot);
+	const allowedFormats = [
+		'JPEG', // Used by Miiverse and Miiverse-enabled games
+		'BMP' // Used by un-official mods, such as CTGP-7
+	];
+	return ImageMagick.read(screenshot, (img) => {
+		if (!allowedFormats.includes(img.format)) {
+			throw new Error(`Invalid format, got '${img.format}'`);
+		}
+		return processScreenshot(img);
+	});
 }
 
 export type ScreenshotUrls = {

--- a/apps/miiverse-api/src/images.ts
+++ b/apps/miiverse-api/src/images.ts
@@ -1,6 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { readFile } from 'node:fs/promises';
-import { ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColors, Orientation } from '@imagemagick/magick-wasm';
+import { AlphaOption, ColorType, FilterType, Gravity, ImageMagick, initializeImageMagick, Interlace, MagickColors, Orientation } from '@imagemagick/magick-wasm';
 import { deflate, inflate } from 'pako';
 import { logger } from '@/logger';
 import { uploadCDNAsset } from '@/util';
@@ -181,6 +181,10 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 	image.settings.setDefine('JPEG', 'sampling-factor', '2x2');
 	image.settings.interlace = Interlace.Jpeg;
 
+	// Remove alpha if input was an alpha-enabled BMP
+	image.backgroundColor = 'white';
+	image.alpha(AlphaOption.Remove);
+
 	return {
 		jpg: image.write('JPEG', Buffer.from),
 		thumb: image.clone((image) => {
@@ -207,8 +211,32 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 	};
 }
 
-export function processJpgScreenshot(painting: Buffer): Screenshot | null {
-	return ImageMagick.read(painting, 'JPG', processScreenshot);
+export function processAutoScreenshot(screenshot: Buffer): Screenshot | null {
+	let format: 'JPG' | 'BMP';
+
+	// JPEG: FF D8 FF
+	// Used by official Miiverse-enabled games
+	if (
+		screenshot.length >= 3 &&
+		screenshot[0] === 0xff &&
+		screenshot[1] === 0xd8 &&
+		screenshot[2] === 0xff
+	) {
+		format = 'JPG';
+	}
+	// BMP: 42 4D ("BM")
+	// Used by un-official mods, such as CTGP-7
+	else if (
+		screenshot.length >= 2 &&
+		screenshot[0] === 0x42 &&
+		screenshot[1] === 0x4d
+	) {
+		format = 'BMP';
+	} else {
+		return null;
+	}
+
+	return ImageMagick.read(screenshot, format, processScreenshot);
 }
 
 export type ScreenshotUrls = {
@@ -228,7 +256,7 @@ export type UploadScreenshotOptions = {
 export async function uploadScreenshot(opts: UploadScreenshotOptions): Promise<ScreenshotUrls | null> {
 	// try buffer, otherwise blob
 	const screenshotBuf = opts.buffer ?? Buffer.from(opts.blob.replace(/\0/g, '').trim(), 'base64');
-	const screenshots = processJpgScreenshot(screenshotBuf);
+	const screenshots = processAutoScreenshot(screenshotBuf);
 	if (screenshots === null) {
 		return null;
 	}

--- a/apps/miiverse-api/src/images.ts
+++ b/apps/miiverse-api/src/images.ts
@@ -214,7 +214,7 @@ function processScreenshot(image: IMagickImage): Screenshot | null {
 export function processAutoScreenshot(screenshot: Buffer): Screenshot | null {
 	const allowedFormats = [
 		'JPEG', // Used by Miiverse and Miiverse-enabled games
-		'BMP' // Used by un-official mods, such as CTGP-7
+		'BMP', 'BMP3' // Used by un-official mods, such as CTGP-7
 	];
 	return ImageMagick.read(screenshot, (img) => {
 		if (!allowedFormats.includes(img.format)) {


### PR DESCRIPTION
<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #543

### Changes:

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

Changes the `uploadScreenshot` code path in `apps\juxtaposition-ui\src\images.ts` and `apps\miiverse-api\src\images.ts` to accept `BMP` or `JPG` images instead of just `JPG`. The input format is determined by reading the file magic in the buffer. Any other formats return `null`.

This will allow CTGP-7 to upload screenshots to Juxt without having to ship a JPEG encoder.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [ ] I have tested all of my changes.