### PR TITLE
Style(Web): Fix Styling of No Reports Message on Moderation Page

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/reportListView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/admin/reportListView.tsx
@@ -74,7 +74,7 @@ export function WebReportListView(props: ReportListViewProps): ReactNode {
 				<WebModerationTabs selected="reports" />
 				{props.reports.length === 0
 					? (
-							<p>
+							<p className="no-reports-message">
 								All reports handled 🎉
 								<br />
 								Good job team!

--- a/apps/juxtaposition-ui/webfiles/web/css/web.scss
+++ b/apps/juxtaposition-ui/webfiles/web/css/web.scss
@@ -2058,3 +2058,7 @@ button.report {
     margin-bottom: 4rem;
   }
 }
+
+.no-reports-message {
+    margin: 20px auto auto auto;
+  }


### PR DESCRIPTION
Resolves #546

### Changes:

Centered the no reports message by giving it its own class and appropriate margin styling.

See issue page for before image.

After image:

<img width="1384" height="562" alt="image" src="https://github.com/user-attachments/assets/d71a0a2a-9929-4330-8c8a-292ea5ac439b" />


- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.