### PR TITLE
Update Report Reasons

### DIFF
--- a/apps/juxtaposition-ui/src/assets/locales/en.json
+++ b/apps/juxtaposition-ui/src/assets/locales/en.json
@@ -193,7 +193,7 @@
   "reporting": {
     "title": "Report Post",
     "submit": "Submit Report",
-    "description": "You are about to report a post with content which violates the Juxtaposition Code of Conduct. This report will be sent to Pretendo's Juxtaposition administrators and not to the creator of the post.",
+    "description": "You are about to report a post that violates the Juxtaposition Code of Conduct. This report will be sent only to Juxtaposition Moderators and not to the creator of the post.",
     "label": "Reason:",
     "additional_info_placeholder": "Enter additional comments or information",
     "reason_spoiler": "Spoiler",

--- a/apps/juxtaposition-ui/src/assets/locales/en.json
+++ b/apps/juxtaposition-ui/src/assets/locales/en.json
@@ -206,7 +206,20 @@
     "reason_piracy": "Piracy",
     "reason_inappropiate_ingame": "Inappropriate Behavior in Game",
     "reason_missing_images": "Missing Images",
-    "reason_others": "Other"
+    "reason_others": "Other",
+    "reason_not_nice": "Mean/Rude/Hateful (Rule 1)",
+    "reason_inappropriate": "Inappropriate/NSFW (Rule 2)",
+    "reason_spam": "Spam/Self-Promotion (Rule 3)",
+    "reason_offtopic": "Off-Topic (Rule 4)",
+    "reason_piracy_new": "Piracy (Rule 5)",
+    "reason_exploits": "API Abuse/Exploiting Bugs (Rule 8)",
+    "reason_drama": "Drama (Rule 9)",
+    "reason_cheating": "Cheating Online (Rule 10)",
+    "reason_spoiler_new": "Spoiler (Rule 11)",
+    "reason_personal_info_new": "Personal Information (Rule 12)",
+    "reason_politics": "Politics (Rule 13)",
+    "reason_misinformation": "Misinformation/Bad Advice (Rule 14)",
+    "reason_impersonation": "Impersonation (Rule 15)"
   },
   "moderation": {
     "title": "Moderation",

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/reportPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/reportPostView.tsx
@@ -22,20 +22,20 @@ export function CtrReportPostView(props: ReportPostViewProps): ReactNode {
 						{' '}
 					</label>
 					<select name="reason" id="report">
-						<option value="201"><T k="reporting.reason_not_nice" /></option>
-						<option value="202"><T k="reporting.reason_inappropriate" /></option>
-						<option value="203"><T k="reporting.reason_spam" /></option>
-						<option value="204"><T k="reporting.reason_offtopic" /></option>
-						<option value="205"><T k="reporting.reason_piracy_new" /></option>
-						<option value="208"><T k="reporting.reason_exploits" /></option>
-						<option value="209"><T k="reporting.reason_drama" /></option>
-						<option value="210"><T k="reporting.reason_cheating" /></option>
-						<option value="211"><T k="reporting.reason_spoiler_new" /></option>
-						<option value="212"><T k="reporting.reason_personal_info_new" /></option>
-						<option value="213"><T k="reporting.reason_politics" /></option>
-						<option value="214"><T k="reporting.reason_misinformation" /></option>
-						<option value="215"><T k="reporting.reason_impersonation" /></option>
-						<option value="216"><T k="reporting.reason_others" /></option>
+						<option value="11"><T k="reporting.reason_not_nice" /></option>
+						<option value="12"><T k="reporting.reason_inappropriate" /></option>
+						<option value="13"><T k="reporting.reason_spam" /></option>
+						<option value="14"><T k="reporting.reason_offtopic" /></option>
+						<option value="15"><T k="reporting.reason_piracy_new" /></option>
+						<option value="16"><T k="reporting.reason_exploits" /></option>
+						<option value="17"><T k="reporting.reason_drama" /></option>
+						<option value="18"><T k="reporting.reason_cheating" /></option>
+						<option value="19"><T k="reporting.reason_spoiler_new" /></option>
+						<option value="20"><T k="reporting.reason_personal_info_new" /></option>
+						<option value="21"><T k="reporting.reason_politics" /></option>
+						<option value="22"><T k="reporting.reason_misinformation" /></option>
+						<option value="23"><T k="reporting.reason_impersonation" /></option>
+						<option value="10"><T k="reporting.reason_others" /></option>
 					</select>
 				</div>
 				<textarea

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/reportPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/reportPostView.tsx
@@ -22,17 +22,20 @@ export function CtrReportPostView(props: ReportPostViewProps): ReactNode {
 						{' '}
 					</label>
 					<select name="reason" id="report">
-						<option value="0"><T k="reporting.reason_spoiler" /></option>
-						<option value="1"><T k="reporting.reason_personal_info" /></option>
-						<option value="2"><T k="reporting.reason_violence" /></option>
-						<option value="3"><T k="reporting.reason_inappropiate" /></option>
-						<option value="4"><T k="reporting.reason_bullying" /></option>
-						<option value="5"><T k="reporting.reason_advertising" /></option>
-						<option value="6"><T k="reporting.reason_nsfw" /></option>
-						<option value="7"><T k="reporting.reason_piracy" /></option>
-						<option value="8"><T k="reporting.reason_inappropiate_ingame" /></option>
-						<option value="10"><T k="reporting.reason_missing_images" /></option>
-						<option value="9"><T k="reporting.reason_others" /></option>
+						<option value="201"><T k="reporting.reason_not_nice" /></option>
+						<option value="202"><T k="reporting.reason_inappropriate" /></option>
+						<option value="203"><T k="reporting.reason_spam" /></option>
+						<option value="204"><T k="reporting.reason_offtopic" /></option>
+						<option value="205"><T k="reporting.reason_piracy_new" /></option>
+						<option value="208"><T k="reporting.reason_exploits" /></option>
+						<option value="209"><T k="reporting.reason_drama" /></option>
+						<option value="210"><T k="reporting.reason_cheating" /></option>
+						<option value="211"><T k="reporting.reason_spoiler_new" /></option>
+						<option value="212"><T k="reporting.reason_personal_info_new" /></option>
+						<option value="213"><T k="reporting.reason_politics" /></option>
+						<option value="214"><T k="reporting.reason_misinformation" /></option>
+						<option value="215"><T k="reporting.reason_impersonation" /></option>
+						<option value="216"><T k="reporting.reason_others" /></option>
 					</select>
 				</div>
 				<textarea

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/reportPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/ctr/reportPostView.tsx
@@ -35,7 +35,7 @@ export function CtrReportPostView(props: ReportPostViewProps): ReactNode {
 						<option value="21"><T k="reporting.reason_politics" /></option>
 						<option value="22"><T k="reporting.reason_misinformation" /></option>
 						<option value="23"><T k="reporting.reason_impersonation" /></option>
-						<option value="10"><T k="reporting.reason_others" /></option>
+						<option value="9"><T k="reporting.reason_others" /></option>
 					</select>
 				</div>
 				<textarea

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/reportPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/reportPostView.tsx
@@ -17,17 +17,20 @@ export function PortalReportPostView(props: ReportPostViewProps): ReactNode {
 					<div>
 						<h4><T k="reporting.label" /></h4>
 						<select name="reason" id="report">
-							<option value="0"><T k="reporting.reason_spoiler" /></option>
-							<option value="1"><T k="reporting.reason_personal_info" /></option>
-							<option value="2"><T k="reporting.reason_violence" /></option>
-							<option value="3"><T k="reporting.reason_inappropiate" /></option>
-							<option value="4"><T k="reporting.reason_bullying" /></option>
-							<option value="5"><T k="reporting.reason_advertising" /></option>
-							<option value="6"><T k="reporting.reason_nsfw" /></option>
-							<option value="7"><T k="reporting.reason_piracy" /></option>
-							<option value="8"><T k="reporting.reason_inappropiate_ingame" /></option>
-							<option value="10"><T k="reporting.reason_missing_images" /></option>
-							<option value="9"><T k="reporting.reason_others" /></option>
+							<option value="201"><T k="reporting.reason_not_nice" /></option>
+							<option value="202"><T k="reporting.reason_inappropriate" /></option>
+							<option value="203"><T k="reporting.reason_spam" /></option>
+							<option value="204"><T k="reporting.reason_offtopic" /></option>
+							<option value="205"><T k="reporting.reason_piracy_new" /></option>
+							<option value="208"><T k="reporting.reason_exploits" /></option>
+							<option value="209"><T k="reporting.reason_drama" /></option>
+							<option value="210"><T k="reporting.reason_cheating" /></option>
+							<option value="211"><T k="reporting.reason_spoiler_new" /></option>
+							<option value="212"><T k="reporting.reason_personal_info_new" /></option>
+							<option value="213"><T k="reporting.reason_politics" /></option>
+							<option value="214"><T k="reporting.reason_misinformation" /></option>
+							<option value="215"><T k="reporting.reason_impersonation" /></option>
+							<option value="216"><T k="reporting.reason_others" /></option>
 						</select>
 					</div>
 					<textarea name="message" className="textarea-text" value="" maxLength={280} placeholder={T.str('reporting.additional_info_placeholder')}></textarea>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/reportPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/reportPostView.tsx
@@ -17,20 +17,20 @@ export function PortalReportPostView(props: ReportPostViewProps): ReactNode {
 					<div>
 						<h4><T k="reporting.label" /></h4>
 						<select name="reason" id="report">
-							<option value="201"><T k="reporting.reason_not_nice" /></option>
-							<option value="202"><T k="reporting.reason_inappropriate" /></option>
-							<option value="203"><T k="reporting.reason_spam" /></option>
-							<option value="204"><T k="reporting.reason_offtopic" /></option>
-							<option value="205"><T k="reporting.reason_piracy_new" /></option>
-							<option value="208"><T k="reporting.reason_exploits" /></option>
-							<option value="209"><T k="reporting.reason_drama" /></option>
-							<option value="210"><T k="reporting.reason_cheating" /></option>
-							<option value="211"><T k="reporting.reason_spoiler_new" /></option>
-							<option value="212"><T k="reporting.reason_personal_info_new" /></option>
-							<option value="213"><T k="reporting.reason_politics" /></option>
-							<option value="214"><T k="reporting.reason_misinformation" /></option>
-							<option value="215"><T k="reporting.reason_impersonation" /></option>
-							<option value="216"><T k="reporting.reason_others" /></option>
+							<option value="11"><T k="reporting.reason_not_nice" /></option>
+							<option value="12"><T k="reporting.reason_inappropriate" /></option>
+							<option value="13"><T k="reporting.reason_spam" /></option>
+							<option value="14"><T k="reporting.reason_offtopic" /></option>
+							<option value="15"><T k="reporting.reason_piracy_new" /></option>
+							<option value="16"><T k="reporting.reason_exploits" /></option>
+							<option value="17"><T k="reporting.reason_drama" /></option>
+							<option value="18"><T k="reporting.reason_cheating" /></option>
+							<option value="19"><T k="reporting.reason_spoiler_new" /></option>
+							<option value="20"><T k="reporting.reason_personal_info_new" /></option>
+							<option value="21"><T k="reporting.reason_politics" /></option>
+							<option value="22"><T k="reporting.reason_misinformation" /></option>
+							<option value="23"><T k="reporting.reason_impersonation" /></option>
+							<option value="10"><T k="reporting.reason_others" /></option>
 						</select>
 					</div>
 					<textarea name="message" className="textarea-text" value="" maxLength={280} placeholder={T.str('reporting.additional_info_placeholder')}></textarea>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/portal/reportPostView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/portal/reportPostView.tsx
@@ -30,7 +30,7 @@ export function PortalReportPostView(props: ReportPostViewProps): ReactNode {
 							<option value="21"><T k="reporting.reason_politics" /></option>
 							<option value="22"><T k="reporting.reason_misinformation" /></option>
 							<option value="23"><T k="reporting.reason_impersonation" /></option>
-							<option value="10"><T k="reporting.reason_others" /></option>
+							<option value="9"><T k="reporting.reason_others" /></option>
 						</select>
 					</div>
 					<textarea name="message" className="textarea-text" value="" maxLength={280} placeholder={T.str('reporting.additional_info_placeholder')}></textarea>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/reportModalView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/reportModalView.tsx
@@ -18,17 +18,20 @@ export function WebReportModalView(): ReactNode {
 					<div>
 						<h4><T k="reporting.label" /></h4>
 						<select name="reason" id="report">
-							<option value="0"><T k="reporting.reason_spoiler" /></option>
-							<option value="1"><T k="reporting.reason_personal_info" /></option>
-							<option value="2"><T k="reporting.reason_violence" /></option>
-							<option value="3"><T k="reporting.reason_inappropiate" /></option>
-							<option value="4"><T k="reporting.reason_bullying" /></option>
-							<option value="5"><T k="reporting.reason_advertising" /></option>
-							<option value="6"><T k="reporting.reason_nsfw" /></option>
-							<option value="7"><T k="reporting.reason_piracy" /></option>
-							<option value="8"><T k="reporting.reason_inappropiate_ingame" /></option>
-							<option value="10"><T k="reporting.reason_missing_images" /></option>
-							<option value="9"><T k="reporting.reason_others" /></option>
+							<option value="201"><T k="reporting.reason_not_nice" /></option>
+							<option value="202"><T k="reporting.reason_inappropriate" /></option>
+							<option value="203"><T k="reporting.reason_spam" /></option>
+							<option value="204"><T k="reporting.reason_offtopic" /></option>
+							<option value="205"><T k="reporting.reason_piracy_new" /></option>
+							<option value="208"><T k="reporting.reason_exploits" /></option>
+							<option value="209"><T k="reporting.reason_drama" /></option>
+							<option value="210"><T k="reporting.reason_cheating" /></option>
+							<option value="211"><T k="reporting.reason_spoiler_new" /></option>
+							<option value="212"><T k="reporting.reason_personal_info_new" /></option>
+							<option value="213"><T k="reporting.reason_politics" /></option>
+							<option value="214"><T k="reporting.reason_misinformation" /></option>
+							<option value="215"><T k="reporting.reason_impersonation" /></option>
+							<option value="216"><T k="reporting.reason_others" /></option>
 						</select>
 					</div>
 					<textarea name="message" value="" maxLength={280} placeholder="Enter additional comments or information"></textarea>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/reportModalView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/reportModalView.tsx
@@ -31,7 +31,7 @@ export function WebReportModalView(): ReactNode {
 							<option value="21"><T k="reporting.reason_politics" /></option>
 							<option value="22"><T k="reporting.reason_misinformation" /></option>
 							<option value="23"><T k="reporting.reason_impersonation" /></option>
-							<option value="10"><T k="reporting.reason_others" /></option>
+							<option value="9"><T k="reporting.reason_others" /></option>
 						</select>
 					</div>
 					<textarea name="message" value="" maxLength={280} placeholder="Enter additional comments or information"></textarea>

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/reportModalView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/reportModalView.tsx
@@ -18,20 +18,20 @@ export function WebReportModalView(): ReactNode {
 					<div>
 						<h4><T k="reporting.label" /></h4>
 						<select name="reason" id="report">
-							<option value="201"><T k="reporting.reason_not_nice" /></option>
-							<option value="202"><T k="reporting.reason_inappropriate" /></option>
-							<option value="203"><T k="reporting.reason_spam" /></option>
-							<option value="204"><T k="reporting.reason_offtopic" /></option>
-							<option value="205"><T k="reporting.reason_piracy_new" /></option>
-							<option value="208"><T k="reporting.reason_exploits" /></option>
-							<option value="209"><T k="reporting.reason_drama" /></option>
-							<option value="210"><T k="reporting.reason_cheating" /></option>
-							<option value="211"><T k="reporting.reason_spoiler_new" /></option>
-							<option value="212"><T k="reporting.reason_personal_info_new" /></option>
-							<option value="213"><T k="reporting.reason_politics" /></option>
-							<option value="214"><T k="reporting.reason_misinformation" /></option>
-							<option value="215"><T k="reporting.reason_impersonation" /></option>
-							<option value="216"><T k="reporting.reason_others" /></option>
+							<option value="11"><T k="reporting.reason_not_nice" /></option>
+							<option value="12"><T k="reporting.reason_inappropriate" /></option>
+							<option value="13"><T k="reporting.reason_spam" /></option>
+							<option value="14"><T k="reporting.reason_offtopic" /></option>
+							<option value="15"><T k="reporting.reason_piracy_new" /></option>
+							<option value="16"><T k="reporting.reason_exploits" /></option>
+							<option value="17"><T k="reporting.reason_drama" /></option>
+							<option value="18"><T k="reporting.reason_cheating" /></option>
+							<option value="19"><T k="reporting.reason_spoiler_new" /></option>
+							<option value="20"><T k="reporting.reason_personal_info_new" /></option>
+							<option value="21"><T k="reporting.reason_politics" /></option>
+							<option value="22"><T k="reporting.reason_misinformation" /></option>
+							<option value="23"><T k="reporting.reason_impersonation" /></option>
+							<option value="10"><T k="reporting.reason_others" /></option>
 						</select>
 					</div>
 					<textarea name="message" value="" maxLength={280} placeholder="Enter additional comments or information"></textarea>

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -141,7 +141,20 @@ export function getReasonMap(): string[] {
 		'Piracy',
 		'Inappropriate Behavior in Game',
 		'Other',
-		'Missing Images; Reach out to Jemma with post link to fix'
+		'Missing Images; Reach out to Jemma with post link to fix',
+		'Mean/Rude/Hateful (Rule 1)',
+		'Inappropriate/NSFW (Rule 2)',
+		'Spam/Self-Promotion (Rule 3)',
+		'Off-Topic (Rule 4)',
+		'Piracy (Rule 5)',
+		'API Abuse/Exploiting Bugs (Rule 8)',
+		'Drama (Rule 9)',
+		'Cheating Online (Rule 10)',
+		'Spoiler (Rule 11)',
+		'Personal Information (Rule 12)',
+		'Politics (Rule 13)',
+		'Misinformation/Bad Advice (Rule 14)',
+		'Impersonation (Rule 15)'
 	];
 }
 


### PR DESCRIPTION
Resolves #97 

### Changes:

1. Report Reasons now match the current Juxtaposition Code of Conduct
 a. One reason for each reportable rule
 b. Report Reasons are in the same order as the Code of Conduct
 c. Rule numbers are now listed

2. Also updated the text on the report window to have better flow. 

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.