### PR TITLE
fix: allow report reason to be empty

### DIFF
--- a/apps/miiverse-api/src/models/report.ts
+++ b/apps/miiverse-api/src/models/report.ts
@@ -20,7 +20,7 @@ export const ReportSchema = new Schema<IReport, ReportModel>({
 	},
 	message: {
 		type: String,
-		required: true
+		default: ''
 	},
 	created_at: {
 		type: Date,


### PR DESCRIPTION
changes:
- fix: allow report reason to be empty

Apparently juxt-ui and miiverse-api did not have the same mongoose model.

