### PR TITLE
GRPC token update

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   account:
-    image: ghcr.io/pretendonetwork/account:sha-99aec60
+    image: ghcr.io/pretendonetwork/account:sha-fc12061
     restart: unless-stopped
     ports:
       - "8123:8123" # grpc

--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -120,7 +120,7 @@ services:
       PN_ACT_CONFIG_GRPC_MASTER_API_KEY_ACCOUNT: "12345678123456781234567812345678"
       PN_ACT_CONFIG_GRPC_MASTER_API_KEY_API: "12345678123456781234567812345678"
 
-  friends:
+  friends: # Newer versions of friends require dumping decryption keys. We're using an old version to keep local hosting easy
     image: ghcr.io/pretendonetwork/friends:sha-5560c1d
     restart: unless-stopped
     ports:

--- a/apps/juxtaposition-ui/package.json
+++ b/apps/juxtaposition-ui/package.json
@@ -19,7 +19,7 @@
     "@hey-api/openapi-ts": "^0.95.0",
     "@imagemagick/magick-wasm": "^0.0.38",
     "@neato/config": "^4.1.0",
-    "@pretendonetwork/grpc": "^2.4.3",
+    "@pretendonetwork/grpc": "^2.5.3",
     "@repo/grpc-client": "^0.0.0",
     "classnames": "^2.5.1",
     "connect-redis": "^9.0.0",

--- a/apps/juxtaposition-ui/package.json
+++ b/apps/juxtaposition-ui/package.json
@@ -24,7 +24,6 @@
     "classnames": "^2.5.1",
     "connect-redis": "^9.0.0",
     "cookie-parser": "^1.4.7",
-    "crc": "^4.3.2",
     "esbuild-sass-plugin": "^3.7.0",
     "express": "^5.2.1",
     "express-prom-bundle": "^7.0.2",

--- a/apps/juxtaposition-ui/src/middleware/consoleAuth.tsx
+++ b/apps/juxtaposition-ui/src/middleware/consoleAuth.tsx
@@ -4,7 +4,7 @@ import { getLanguage } from '@/i18n';
 import { logger } from '@/logger';
 import { CtrFatalErrorView } from '@/services/juxt-web/views/ctr/errorView';
 import { PortalFatalErrorView } from '@/services/juxt-web/views/portal/errorView';
-import { decodeParamPack, getPIDFromServiceToken, getUserAccountData, getUserDataFromToken } from '@/util';
+import { decodeParamPack, getUserAccountData, getUserDataFromServiceToken, getUserDataFromToken } from '@/util';
 import type { RequestHandler, Response } from 'express';
 
 function renderAuthError(res: Response, code: number, message: string): void {
@@ -22,8 +22,14 @@ export const consoleAuth: RequestHandler = async (request, response, next) => {
 		request.tokens = request.session.tokens;
 	} else {
 		request.tokens = { serviceToken: request.get('x-nintendo-servicetoken') };
-		request.pid = request.headers['x-nintendo-servicetoken'] ? getPIDFromServiceToken(request.get('x-nintendo-servicetoken') ?? '') : null;
-		request.user = request.pid ? await getUserAccountData(request.pid) : null;
+		request.pid = null;
+		request.user = null;
+
+		if (request.tokens.serviceToken) {
+			const pnid = await getUserDataFromServiceToken(request.tokens.serviceToken);
+			request.user = pnid ?? null;
+			request.pid = pnid?.pid ?? null;
+		}
 
 		request.session.user = request.user;
 		request.session.pid = request.pid;

--- a/apps/juxtaposition-ui/src/services/juxt-web/routes/routeUtils.ts
+++ b/apps/juxtaposition-ui/src/services/juxt-web/routes/routeUtils.ts
@@ -1,4 +1,4 @@
-import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { Request } from 'express';
 import type { z } from 'zod';
 import type { UserTokens } from '@/types/juxt/tokens';

--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/postPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/postPageView.tsx
@@ -7,7 +7,7 @@ import { T } from '@/services/juxt-web/views/common/components/T';
 import { useUser } from '@/services/juxt-web/views/common/hooks/useUser';
 import { WebUIIcon } from '@/services/juxt-web/views/web/components/ui/WebUIIcon';
 import type { ReactNode } from 'react';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { Community, Post, SelfContent } from '@/api/generated';
 
 export type PostPageViewProps = {

--- a/apps/juxtaposition-ui/src/types/common/service-token.ts
+++ b/apps/juxtaposition-ui/src/types/common/service-token.ts
@@ -1,8 +1,0 @@
-export interface ServiceToken {
-	system_type: number;
-	token_type: number;
-	pid: number;
-	access_level: number;
-	title_id: bigint;
-	issue_time: bigint;
-}

--- a/apps/juxtaposition-ui/src/types/common/system-types.ts
+++ b/apps/juxtaposition-ui/src/types/common/system-types.ts
@@ -1,6 +1,0 @@
-export enum SystemType {
-	WUP = 1,
-	CTR = 2,
-	API = 3,
-	PasswordReset = 0xFF // * This kinda blows
-}

--- a/apps/juxtaposition-ui/src/types/common/token-types.ts
+++ b/apps/juxtaposition-ui/src/types/common/token-types.ts
@@ -1,7 +1,0 @@
-export enum TokenType {
-	OAuthAccess = 1,
-	OAuthRefresh = 2,
-	NEX = 3,
-	IndependentService = 4,
-	PasswordReset = 5
-}

--- a/apps/juxtaposition-ui/src/types/express.d.ts
+++ b/apps/juxtaposition-ui/src/types/express.d.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/consistent-type-imports -- other methods of importing type dont work */
 
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { i18n } from 'i18next';
 import type { ParamPack } from '@/types/common/param-pack';
 import type { UserTokens } from '@/types/juxt/tokens';

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -2,8 +2,8 @@ import crypto from 'crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createChannel, createClient, Metadata } from 'nice-grpc';
-import { AccountDefinition } from '@pretendonetwork/grpc/account/account_service';
-import { APIDefinition } from '@pretendonetwork/grpc/api/api_service';
+import { AccountServiceDefinition } from '@pretendonetwork/grpc/account/v2/account_service';
+import { ApiServiceDefinition } from '@pretendonetwork/grpc/api/v2/api_service';
 import crc32 from 'crc/crc32';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
@@ -14,19 +14,19 @@ import { SystemType } from '@/types/common/system-types';
 import { TokenType } from '@/types/common/token-types';
 import type { Options as RatelimitOptions } from 'express-rate-limit';
 import type { ZodType } from 'zod';
-import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
-import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/get_user_data_rpc';
-import type { LoginResponse } from '@pretendonetwork/grpc/api/login_rpc';
+import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
+import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/v2/get_user_data_rpc';
+import type { LoginResponse } from '@pretendonetwork/grpc/api/v2/login_rpc';
 import type { RequestHandler } from 'express';
 import type { Config } from '@/config';
 import type { ServiceToken } from '@/types/common/service-token';
 import type { ParamPack } from '@/types/common/param-pack';
 
 const gRPCAccountChannel = createChannel(`${config.grpc.account.host}:${config.grpc.account.port}`);
-const gRPCAccountClient = createClient(AccountDefinition, gRPCAccountChannel);
+const gRPCAccountClient = createClient(AccountServiceDefinition, gRPCAccountChannel);
 
 const gRPCApiChannel = createChannel(`${config.grpc.account.host}:${config.grpc.account.port}`);
-const gRPCApiClient = createClient(APIDefinition, gRPCApiChannel);
+const gRPCApiClient = createClient(ApiServiceDefinition, gRPCApiChannel);
 
 export function decodeParamPack(paramPack: string): ParamPack {
 	const values = Buffer.from(paramPack, 'base64').toString().split('\\').filter(v => v.length > 0).values();
@@ -158,14 +158,15 @@ export function getReasonMap(): string[] {
 	];
 }
 
-export function getUserAccountData(pid: number): Promise<AccountGetUserDataResponse> {
-	return gRPCAccountClient.getUserData({
+export async function getUserAccountData(pid: number): Promise<AccountGetUserDataResponse> {
+	const result: AccountGetUserDataResponse = await gRPCAccountClient.getPNID({
 		pid: pid
 	}, {
 		metadata: Metadata({
 			'X-API-Key': config.grpc.account.apiKey
 		})
 	});
+	return result;
 }
 
 export async function getUserDataFromToken(token: string): Promise<ApiGetUserDataResponse> {

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -1,25 +1,22 @@
-import crypto from 'crypto';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createChannel, createClient, Metadata } from 'nice-grpc';
 import { AccountServiceDefinition } from '@pretendonetwork/grpc/account/v2/account_service';
 import { ApiServiceDefinition } from '@pretendonetwork/grpc/api/v2/api_service';
-import crc32 from 'crc/crc32';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
 import { rateLimit } from 'express-rate-limit';
+import { SystemType } from '@pretendonetwork/grpc/account/v2/token_info';
 import { logger } from '@/logger';
 import { config } from '@/config';
-import { SystemType } from '@/types/common/system-types';
-import { TokenType } from '@/types/common/token-types';
 import type { Options as RatelimitOptions } from 'express-rate-limit';
 import type { ZodType } from 'zod';
 import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/v2/get_user_data_rpc';
 import type { LoginResponse } from '@pretendonetwork/grpc/api/v2/login_rpc';
 import type { RequestHandler } from 'express';
+import type { GetPNIDResponse } from '@pretendonetwork/grpc/account/v2/get_pnid_rpc';
 import type { Config } from '@/config';
-import type { ServiceToken } from '@/types/common/service-token';
 import type { ParamPack } from '@/types/common/param-pack';
 
 const gRPCAccountChannel = createChannel(`${config.grpc.account.host}:${config.grpc.account.port}`);
@@ -63,70 +60,40 @@ export function decodeParamPack(paramPack: string): ParamPack {
 	};
 }
 
-export function getPIDFromServiceToken(token: string): number | null {
+export async function getUserDataFromServiceToken(token: string): Promise<GetPNIDResponse | null> {
 	try {
-		const decryptedToken = decryptToken(Buffer.from(token, 'base64'));
+		const userData = await gRPCAccountClient.exchangeIndependentServiceTokenForUserData({
+			token
+		});
 
-		if (!decryptedToken) {
-			return null;
+		const unpackedToken = userData.tokenInfo;
+		if (!unpackedToken) {
+			throw new Error('No tokenInfo on service token');
+		}
+		if (!unpackedToken.issueTime) {
+			throw new Error('No issueTime on service token');
 		}
 
-		const unpackedToken = unpackServiceToken(decryptedToken);
-		if (unpackedToken === null) {
-			return null;
-		}
-
-		// * Only allow token types 1 (Wii U) and 2 (3DS)
-		if (unpackedToken.system_type !== SystemType.CTR && unpackedToken.system_type !== SystemType.WUP) {
+		// * Only allow CTR and WUP tokens
+		if (![SystemType.SYSTEM_TYPE_CTR, SystemType.SYSTEM_TYPE_WUP].includes(unpackedToken.systemType)) {
 			return null;
 		}
 
 		// * Check if the token is expired
-		if (unpackedToken.issue_time + (24n * 3600n * 1000n) < Date.now()) {
+		const expiryTime = 24 * 60 * 60 * 1000; // 24 hours
+		if (new Date(unpackedToken.issueTime.getTime() + expiryTime) < new Date()) {
 			return null;
 		}
 
-		return unpackedToken.pid;
+		if (!userData.pnid) {
+			return null;
+		}
+
+		return userData.pnid;
 	} catch (e) {
 		logger.error(e, 'Failed to extract PID from service token');
 		return null;
 	}
-}
-
-function decryptToken(token: Buffer): Buffer {
-	const iv = Buffer.alloc(16);
-
-	const expectedChecksum = token.readUint32BE();
-	const encryptedBody = token.subarray(4);
-
-	const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(config.aesKey, 'hex'), iv);
-
-	const decrypted = Buffer.concat([
-		decipher.update(encryptedBody),
-		decipher.final()
-	]);
-
-	if (expectedChecksum !== crc32(decrypted)) {
-		throw new Error('Checksum did not match. Failed decrypt. Are you using the right key?');
-	}
-
-	return decrypted;
-}
-
-export function unpackServiceToken(token: Buffer): ServiceToken | null {
-	const token_type = token.readUInt8(0x1);
-	if (token_type !== TokenType.IndependentService) {
-		return null;
-	}
-
-	return {
-		system_type: token.readUInt8(0x0),
-		token_type: token.readUInt8(0x1),
-		pid: token.readUInt32LE(0x2),
-		issue_time: token.readBigUInt64LE(0x6),
-		title_id: token.readBigUInt64LE(0xE),
-		access_level: token.readInt8(0x16)
-	};
 }
 
 export function getReasonMap(): string[] {

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -126,7 +126,8 @@ export function getReasonMap(): string[] {
 }
 
 export async function getUserAccountData(pid: number): Promise<AccountGetUserDataResponse> {
-	const result: AccountGetUserDataResponse = await gRPCAccountClient.getPNID({
+	// getUserData is deprecated, but the alternatives aren't implemented yet...
+	const result: AccountGetUserDataResponse = await gRPCAccountClient.getUserData({
 		pid: pid
 	}, {
 		metadata: Metadata({

--- a/apps/juxtaposition-ui/src/util.ts
+++ b/apps/juxtaposition-ui/src/util.ts
@@ -64,6 +64,10 @@ export async function getUserDataFromServiceToken(token: string): Promise<GetPNI
 	try {
 		const userData = await gRPCAccountClient.exchangeIndependentServiceTokenForUserData({
 			token
+		}, {
+			metadata: Metadata({
+				'X-API-Key': config.grpc.account.apiKey
+			})
 		});
 
 		const unpackedToken = userData.tokenInfo;

--- a/apps/miiverse-api/package.json
+++ b/apps/miiverse-api/package.json
@@ -22,7 +22,7 @@
 		"@aws-sdk/client-s3": "^3.1004.0",
 		"@imagemagick/magick-wasm": "^0.0.38",
 		"@neato/config": "^4.1.0",
-		"@pretendonetwork/grpc": "^2.4.3",
+		"@pretendonetwork/grpc": "^2.5.3",
 		"@prisma/adapter-pg": "^7.8.0",
 		"@prisma/client": "^7.8.0",
 		"@repo/grpc-client": "^0.0.0",

--- a/apps/miiverse-api/package.json
+++ b/apps/miiverse-api/package.json
@@ -26,7 +26,6 @@
 		"@prisma/adapter-pg": "^7.8.0",
 		"@prisma/client": "^7.8.0",
 		"@repo/grpc-client": "^0.0.0",
-		"crc": "^4.3.2",
 		"express": "^5.2.1",
 		"express-prom-bundle": "^7.0.2",
 		"express-rate-limit": "^8.2.1",

--- a/apps/miiverse-api/src/grpc.ts
+++ b/apps/miiverse-api/src/grpc.ts
@@ -1,13 +1,13 @@
 import { createChannel, createClient, Metadata } from 'nice-grpc';
-import { FriendsDefinition } from '@pretendonetwork/grpc/friends/friends_service';
-import { AccountDefinition } from '@pretendonetwork/grpc/account/account_service';
-import { APIDefinition } from '@pretendonetwork/grpc/api/api_service';
+import { ApiServiceDefinition } from '@pretendonetwork/grpc/api/v2/api_service';
+import { AccountServiceDefinition } from '@pretendonetwork/grpc/account/v2/account_service';
+import { FriendsServiceDefinition } from '@pretendonetwork/grpc/friends/v2/friends_service';
 import { config } from '@/config';
 import type { Client, CompatServiceDefinition } from 'nice-grpc';
 
-export const grpcFriends = grpcFactory(FriendsDefinition);
-export const grpcAccount = grpcFactory(AccountDefinition);
-export const grpcApi = grpcFactory(APIDefinition);
+export const grpcFriends = grpcFactory(FriendsServiceDefinition);
+export const grpcAccount = grpcFactory(AccountServiceDefinition);
+export const grpcApi = grpcFactory(ApiServiceDefinition);
 
 type GrpcConnection<T extends CompatServiceDefinition> = {
 	client(): Client<T>;

--- a/apps/miiverse-api/src/grpc.ts
+++ b/apps/miiverse-api/src/grpc.ts
@@ -1,11 +1,13 @@
 import { createChannel, createClient, Metadata } from 'nice-grpc';
 import { ApiServiceDefinition } from '@pretendonetwork/grpc/api/v2/api_service';
 import { AccountServiceDefinition } from '@pretendonetwork/grpc/account/v2/account_service';
-import { FriendsServiceDefinition } from '@pretendonetwork/grpc/friends/v2/friends_service';
+import { FriendsDefinition } from '@pretendonetwork/grpc/friends/friends_service';
 import { config } from '@/config';
 import type { Client, CompatServiceDefinition } from 'nice-grpc';
 
-export const grpcFriends = grpcFactory(FriendsServiceDefinition);
+// Newer versions of friends require dumping decryption keys. We're using an old version to keep local hosting easy
+export const oldGrpcFriends = grpcFactory(FriendsDefinition);
+
 export const grpcAccount = grpcFactory(AccountServiceDefinition);
 export const grpcApi = grpcFactory(ApiServiceDefinition);
 
@@ -53,7 +55,7 @@ function grpcFactory<T extends CompatServiceDefinition>(definition: T): GrpcConn
 }
 
 export function connectGrpc() {
-	grpcFriends.connect(config.grpc.friends);
+	oldGrpcFriends.connect(config.grpc.friends);
 	grpcAccount.connect(config.grpc.account);
 	grpcApi.connect(config.grpc.account);
 }

--- a/apps/miiverse-api/src/middleware/auth.ts
+++ b/apps/miiverse-api/src/middleware/auth.ts
@@ -1,10 +1,9 @@
 import moment from 'moment';
 import * as z from 'zod';
-import { getUserAccountData, getValueFromHeaders, decodeParamPack, getPIDFromServiceToken } from '@/util';
+import { getValueFromHeaders, decodeParamPack, getUserDataFromServiceToken } from '@/util';
 import { getEndpoint, getUserSettings } from '@/database';
 import { badRequest, ApiErrorCode, serverError } from '@/errors';
 import type express from 'express';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
 
 const ParamPackSchema = z.object({
 	title_id: z.string(),
@@ -34,17 +33,17 @@ async function auth(request: express.Request, response: express.Response, next: 
 		return next();
 	}
 
-	let encryptedToken = getValueFromHeaders(request.headers, 'x-nintendo-servicetoken');
-	if (!encryptedToken) {
-		encryptedToken = getValueFromHeaders(request.headers, 'olive service token');
+	let token = getValueFromHeaders(request.headers, 'x-nintendo-servicetoken');
+	if (!token) {
+		token = getValueFromHeaders(request.headers, 'olive service token');
 	}
 
-	if (!encryptedToken) {
+	if (!token) {
 		return badRequest(response, ApiErrorCode.NO_TOKEN);
 	}
 
-	const pid = getPIDFromServiceToken(encryptedToken);
-	if (pid === null) {
+	const pnid = await getUserDataFromServiceToken(token);
+	if (pnid === null) {
 		return badRequest(response, ApiErrorCode.BAD_TOKEN);
 	}
 
@@ -60,31 +59,22 @@ async function auth(request: express.Request, response: express.Response, next: 
 		return badRequest(response, ApiErrorCode.BAD_PARAM_PACK);
 	}
 
-	let user: GetUserDataResponse;
-
-	try {
-		user = await getUserAccountData(pid);
-	} catch (error) {
-		request.log.error(error, `Failed to get account data for ${pid}`);
-		return serverError(response, ApiErrorCode.ACCOUNT_SERVER_ERROR);
-	}
-
-	const discovery = await getEndpoint(user.serverAccessLevel);
+	const discovery = await getEndpoint(pnid.serverAccessLevel);
 
 	if (!discovery) {
-		request.log.error(`Discovery data is missing for ${user.serverAccessLevel}`);
+		request.log.error(`Discovery data is missing for ${pnid.serverAccessLevel}`);
 		return serverError(response, ApiErrorCode.NO_DISCOVERY_DATA);
 	}
 
 	if (discovery.status > 0 && discovery.status <= 7) {
 		return badRequest(response, discovery.status);
 	} else if (discovery.status !== 0) {
-		request.log.error(`Discovery status ${discovery.status} unexpected for ${user.serverAccessLevel}`);
+		request.log.error(`Discovery status ${discovery.status} unexpected for ${pnid.serverAccessLevel}`);
 		return serverError(response, ApiErrorCode.NO_DISCOVERY_DATA);
 	}
 
-	request.user = user;
-	request.pid = pid;
+	request.user = pnid;
+	request.pid = pnid.pid;
 	request.paramPack = paramPackData;
 
 	const userSettings = await getUserSettings(request.pid);
@@ -103,7 +93,7 @@ async function auth(request: express.Request, response: express.Response, next: 
 
 	// This includes ban checks for both Juxt specifically and the account server, ideally this should be squashed
 	// assuming we support more gradual bans on PNID's
-	if (userSettings.account_status < 0 || userSettings.account_status > 1 || user.accessLevel < 0) {
+	if (userSettings.account_status < 0 || userSettings.account_status > 1 || pnid.accessLevel < 0) {
 		if (userSettings.account_status === 2 && request.method === 'GET') {
 			return next();
 		} else if (userSettings.account_status === 2) {

--- a/apps/miiverse-api/src/services/api/routes/friend_messages.ts
+++ b/apps/miiverse-api/src/services/api/routes/friend_messages.ts
@@ -16,7 +16,7 @@ import { Conversation } from '@/models/conversation';
 import { config } from '@/config';
 import { ApiErrorCode, badRequest, serverError } from '@/errors';
 import { uploadPainting, uploadScreenshot } from '@/images';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { FormattedMessage } from '@/types/common/formatted-message';
 
 const sendMessageSchema = z.object({

--- a/apps/miiverse-api/src/services/api/routes/posts.ts
+++ b/apps/miiverse-api/src/services/api/routes/posts.ts
@@ -24,7 +24,7 @@ import { ApiErrorCode, badRequest, serverError } from '@/errors';
 import { uploadPainting, uploadScreenshot } from '@/images';
 import { cleanedBase64 } from '@/zodUtils';
 import { AutomodRule } from '@/models/automodRules';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { PostRepliesResult } from '@/types/miiverse/post';
 import type { HydratedPostDocument, IPostInput } from '@/types/mongoose/post';
 import type { CommunityShotMode, HydratedCommunityDocument } from '@/types/mongoose/community';

--- a/apps/miiverse-api/src/services/internal/contract/admin/adminUsers.ts
+++ b/apps/miiverse-api/src/services/internal/contract/admin/adminUsers.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { mapUserProfile, userProfileSchema } from '@/services/internal/contract/user';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { HydratedSettingsDocument } from '@/types/mongoose/settings';
 
 export const adminUserProfileSchema = userProfileSchema.extend({

--- a/apps/miiverse-api/src/services/internal/contract/self.ts
+++ b/apps/miiverse-api/src/services/internal/contract/self.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { asOpenapi } from '@/services/internal/builder/openapi';
 import { mapShallowUser, shallowUserSchema } from '@/services/internal/contract/user';
-import type { FriendRequest } from '@pretendonetwork/grpc/friends/v2/friend_request';
+import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
 import type { AccountData } from '@/types/common/account-data';
 import type { HydratedSettingsDocument } from '@/types/mongoose/settings';
 

--- a/apps/miiverse-api/src/services/internal/contract/self.ts
+++ b/apps/miiverse-api/src/services/internal/contract/self.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { asOpenapi } from '@/services/internal/builder/openapi';
 import { mapShallowUser, shallowUserSchema } from '@/services/internal/contract/user';
-import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
+import type { FriendRequest } from '@pretendonetwork/grpc/friends/v2/friend_request';
 import type { AccountData } from '@/types/common/account-data';
 import type { HydratedSettingsDocument } from '@/types/mongoose/settings';
 

--- a/apps/miiverse-api/src/services/internal/contract/user.ts
+++ b/apps/miiverse-api/src/services/internal/contract/user.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { asOpenapi } from '@/services/internal/builder/openapi';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { HydratedSettingsDocument } from '@/types/mongoose/settings';
 
 export const userBadgeSchema = z.enum([

--- a/apps/miiverse-api/src/services/internal/middleware/auth-populate.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/auth-populate.ts
@@ -45,7 +45,7 @@ export async function authPopulate(request: express.Request, response: express.R
 async function consoleAuth(_request: express.Request, serviceToken: string): Promise<GetUserDataResponse> {
 	const pnid: GetUserDataResponse | null = await getUserDataFromServiceToken(serviceToken);
 	if (!pnid) {
-		throw new Error('Could not extract PNID from service token');
+		throw errors.for('unauthorized', 'Invalid service token!');
 	}
 	return pnid;
 }

--- a/apps/miiverse-api/src/services/internal/middleware/auth-populate.ts
+++ b/apps/miiverse-api/src/services/internal/middleware/auth-populate.ts
@@ -1,8 +1,8 @@
-import { getPIDFromServiceToken, getUserAccountData, getUserDataFromToken, getValueFromHeaders } from '@/util';
+import { getUserAccountData, getUserDataFromServiceToken, getUserDataFromToken, getValueFromHeaders } from '@/util';
 import { errors } from '@/services/internal/errors';
 import { getUserContent, getUserSettings } from '@/database';
 import type express from 'express';
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 
 /**
  * Handles authentication for service (NNAS/console) and OAuth (web) tokens. Sets locals.account to AccountData.
@@ -43,14 +43,10 @@ export async function authPopulate(request: express.Request, response: express.R
 }
 
 async function consoleAuth(_request: express.Request, serviceToken: string): Promise<GetUserDataResponse> {
-	const pid = getPIDFromServiceToken(serviceToken);
-	if (pid === null) {
-		throw errors.for('unauthorized', 'Invalid service token!');
+	const pnid: GetUserDataResponse | null = await getUserDataFromServiceToken(serviceToken);
+	if (!pnid) {
+		throw new Error('Could not extract PNID from service token');
 	}
-
-	// If the user has a valid token for an unknown PID, just let the exception bubble
-	const pnid = await getUserAccountData(pid);
-
 	return pnid;
 }
 

--- a/apps/miiverse-api/src/types/common/account-data.ts
+++ b/apps/miiverse-api/src/types/common/account-data.ts
@@ -1,4 +1,4 @@
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { HydratedSettingsDocument } from '@/types/mongoose/settings';
 import type { HydratedContentDocument } from '@/types/mongoose/content';
 

--- a/apps/miiverse-api/src/types/common/service-token.ts
+++ b/apps/miiverse-api/src/types/common/service-token.ts
@@ -1,8 +1,0 @@
-export interface ServiceToken {
-	system_type: number;
-	token_type: number;
-	pid: number;
-	access_level: number;
-	title_id: bigint;
-	issue_time: bigint;
-}

--- a/apps/miiverse-api/src/types/common/system-types.ts
+++ b/apps/miiverse-api/src/types/common/system-types.ts
@@ -1,6 +1,0 @@
-export enum SystemType {
-	WUP = 1,
-	CTR = 2,
-	API = 3,
-	PasswordReset = 0xFF // * This kinda blows
-}

--- a/apps/miiverse-api/src/types/common/token-types.ts
+++ b/apps/miiverse-api/src/types/common/token-types.ts
@@ -1,7 +1,0 @@
-export enum TokenType {
-	OAuthAccess = 1,
-	OAuthRefresh = 2,
-	NEX = 3,
-	IndependentService = 4,
-	PasswordReset = 5
-}

--- a/apps/miiverse-api/src/types/express.d.ts
+++ b/apps/miiverse-api/src/types/express.d.ts
@@ -1,4 +1,4 @@
-import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
+import type { GetUserDataResponse } from '@pretendonetwork/grpc/account/v2/get_user_data_rpc';
 import type { ParamPack } from '@/types/common/param-pack';
 import type { ApiErrorCode } from '@/errors';
 import type { AccountData } from '@/types/common/account-data';

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -3,12 +3,12 @@ import { DeleteObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { SystemType } from '@pretendonetwork/grpc/account/v2/token_info';
 import { config } from '@/config';
 import { logger } from '@/logger';
-import { grpcAccount, grpcApi, grpcFriends } from '@/grpc';
+import { grpcAccount, grpcApi, oldGrpcFriends } from '@/grpc';
 import { getS3 } from '@/s3';
 import { AutomodLog } from '@/models/automodLog';
 import type { IncomingHttpHeaders } from 'node:http';
 import type { ObjectCannedACL } from '@aws-sdk/client-s3';
-import type { FriendRequest } from '@pretendonetwork/grpc/friends/v2/friend_request';
+import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
 import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/v2/get_user_data_rpc';
 import type { ParsedQs } from 'qs';
 import type { GetPNIDResponse } from '@pretendonetwork/grpc/account/v2/get_pnid_rpc';
@@ -133,7 +133,7 @@ export async function bulkDeleteCDNAsset(keys: string[]): Promise<boolean> {
 }
 
 export async function getUserFriendPIDs(pid: number): Promise<number[]> {
-	const response = await grpcFriends.client().getUserFriendPIDs({
+	const response = await oldGrpcFriends.client().getUserFriendPIDs({
 		pid: pid
 	});
 
@@ -141,7 +141,7 @@ export async function getUserFriendPIDs(pid: number): Promise<number[]> {
 }
 
 export async function getUserFriendRequestsIncoming(pid: number): Promise<FriendRequest[]> {
-	const response = await grpcFriends.client().getUserFriendRequestsIncoming({
+	const response = await oldGrpcFriends.client().getUserFriendRequestsIncoming({
 		pid: pid
 	});
 

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -149,7 +149,8 @@ export async function getUserFriendRequestsIncoming(pid: number): Promise<Friend
 }
 
 export function getUserAccountData(pid: number): Promise<GetPNIDResponse> {
-	return grpcAccount.client().getPNID({
+	// getUserData is deprecated, but the alternatives aren't implemented yet...
+	return grpcAccount.client().getUserData({
 		pid
 	});
 }

--- a/apps/miiverse-api/src/util.ts
+++ b/apps/miiverse-api/src/util.ts
@@ -1,22 +1,19 @@
-import crypto, { randomUUID } from 'node:crypto';
+import { randomUUID } from 'node:crypto';
 import { DeleteObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3';
-import crc32 from 'crc/crc32';
+import { SystemType } from '@pretendonetwork/grpc/account/v2/token_info';
 import { config } from '@/config';
 import { logger } from '@/logger';
-import { SystemType } from '@/types/common/system-types';
-import { TokenType } from '@/types/common/token-types';
 import { grpcAccount, grpcApi, grpcFriends } from '@/grpc';
 import { getS3 } from '@/s3';
 import { AutomodLog } from '@/models/automodLog';
 import type { IncomingHttpHeaders } from 'node:http';
 import type { ObjectCannedACL } from '@aws-sdk/client-s3';
-import type { FriendRequest } from '@pretendonetwork/grpc/friends/friend_request';
-import type { GetUserDataResponse as AccountGetUserDataResponse } from '@pretendonetwork/grpc/account/get_user_data_rpc';
-import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/get_user_data_rpc';
+import type { FriendRequest } from '@pretendonetwork/grpc/friends/v2/friend_request';
+import type { GetUserDataResponse as ApiGetUserDataResponse } from '@pretendonetwork/grpc/api/v2/get_user_data_rpc';
 import type { ParsedQs } from 'qs';
+import type { GetPNIDResponse } from '@pretendonetwork/grpc/account/v2/get_pnid_rpc';
 import type { AutomodAction } from '@/models/automodLog';
 import type { ParamPack } from '@/types/common/param-pack';
-import type { ServiceToken } from '@/types/common/service-token';
 import type { IPostInput } from '@/types/mongoose/post';
 import type { HydratedAutomodRuleDocument } from '@/models/automodRules';
 
@@ -60,70 +57,40 @@ export function decodeParamPack(paramPack: string): ParamPack {
 	};
 }
 
-export function getPIDFromServiceToken(token: string): number | null {
+export async function getUserDataFromServiceToken(token: string): Promise<GetPNIDResponse | null> {
 	try {
-		const decryptedToken = decryptToken(Buffer.from(token, 'base64'));
+		const userData = await grpcAccount.client().exchangeIndependentServiceTokenForUserData({
+			token
+		});
 
-		if (!decryptedToken) {
-			return null;
+		const unpackedToken = userData.tokenInfo;
+		if (!unpackedToken) {
+			throw new Error('No tokenInfo on service token');
+		}
+		if (!unpackedToken.issueTime) {
+			throw new Error('No issueTime on service token');
 		}
 
-		const unpackedToken = unpackServiceToken(decryptedToken);
-		if (unpackedToken === null) {
-			return null;
-		}
-
-		// * Only allow token types 1 (Wii U) and 2 (3DS)
-		if (unpackedToken.system_type !== SystemType.CTR && unpackedToken.system_type !== SystemType.WUP) {
+		// * Only allow CTR and WUP tokens
+		if (![SystemType.SYSTEM_TYPE_CTR, SystemType.SYSTEM_TYPE_WUP].includes(unpackedToken.systemType)) {
 			return null;
 		}
 
 		// * Check if the token is expired
-		if (unpackedToken.issue_time + (24n * 3600n * 1000n) < Date.now()) {
+		const expiryTime = 24 * 60 * 60 * 1000; // 24 hours
+		if (new Date(unpackedToken.issueTime.getTime() + expiryTime) < new Date()) {
 			return null;
 		}
 
-		return unpackedToken.pid;
+		if (!userData.pnid) {
+			return null;
+		}
+
+		return userData.pnid;
 	} catch (e) {
 		logger.error(e, 'Failed to extract PID from service token');
 		return null;
 	}
-}
-
-export function decryptToken(token: Buffer): Buffer {
-	const iv = Buffer.alloc(16);
-
-	const expectedChecksum = token.readUint32BE();
-	const encryptedBody = token.subarray(4);
-
-	const decipher = crypto.createDecipheriv('aes-256-cbc', Buffer.from(config.aesKey, 'hex'), iv);
-
-	const decrypted = Buffer.concat([
-		decipher.update(encryptedBody),
-		decipher.final()
-	]);
-
-	if (expectedChecksum !== crc32(decrypted)) {
-		throw new Error('Checksum did not match. Failed decrypt. Are you using the right key?');
-	}
-
-	return decrypted;
-}
-
-export function unpackServiceToken(token: Buffer): ServiceToken | null {
-	const token_type = token.readUInt8(0x1);
-	if (token_type !== TokenType.IndependentService) {
-		return null;
-	}
-
-	return {
-		system_type: token.readUInt8(0x0),
-		token_type: token.readUInt8(0x1),
-		pid: token.readUInt32LE(0x2),
-		issue_time: token.readBigUInt64LE(0x6),
-		title_id: token.readBigUInt64LE(0xE),
-		access_level: token.readInt8(0x16)
-	};
 }
 
 export async function uploadCDNAsset(key: string, data: Buffer, acl: ObjectCannedACL): Promise<boolean> {
@@ -181,9 +148,9 @@ export async function getUserFriendRequestsIncoming(pid: number): Promise<Friend
 	return response.friendRequests;
 }
 
-export function getUserAccountData(pid: number): Promise<AccountGetUserDataResponse> {
-	return grpcAccount.client().getUserData({
-		pid: pid
+export function getUserAccountData(pid: number): Promise<GetPNIDResponse> {
+	return grpcAccount.client().getPNID({
+		pid
 	});
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -383,13 +383,14 @@
         },
         "apps/miiverse-api": {
             "version": "3.0.0",
+            "hasInstallScript": true,
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@asteasolutions/zod-to-openapi": "^8.5.0",
                 "@aws-sdk/client-s3": "^3.1004.0",
                 "@imagemagick/magick-wasm": "^0.0.38",
                 "@neato/config": "^4.1.0",
-                "@pretendonetwork/grpc": "^2.4.3",
+                "@pretendonetwork/grpc": "^2.5.3",
                 "@prisma/adapter-pg": "^7.8.0",
                 "@prisma/client": "^7.8.0",
                 "@repo/grpc-client": "^0.0.0",
@@ -3207,9 +3208,9 @@
             }
         },
         "node_modules/@pretendonetwork/grpc": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/@pretendonetwork/grpc/-/grpc-2.4.3.tgz",
-            "integrity": "sha512-jfghAQpUa1RvKI29QILi/l2+QeTk7/BzYE2/VcNtupeqX8d+7jFbG5VxeHNyNqVPE4Bew8qUWvUy9dTdFVh+qw==",
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/@pretendonetwork/grpc/-/grpc-2.5.3.tgz",
+            "integrity": "sha512-4Vn46SZRTcaI9DS11Es+9/HqywwFHkhjC/yOJwRPebG8lbzlxy2iA03KVhFoxqFKPxepV4Jo76CzOHQ8zd9bcQ==",
             "license": "AGPL-3.0-only",
             "dependencies": {
                 "@bufbuild/protobuf": "^2.2.2",
@@ -5119,7 +5120,6 @@
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "devOptional": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
                 "classnames": "^2.5.1",
                 "connect-redis": "^9.0.0",
                 "cookie-parser": "^1.4.7",
-                "crc": "^4.3.2",
                 "esbuild-sass-plugin": "^3.7.0",
                 "express": "^5.2.1",
                 "express-prom-bundle": "^7.0.2",
@@ -394,7 +393,6 @@
                 "@prisma/adapter-pg": "^7.8.0",
                 "@prisma/client": "^7.8.0",
                 "@repo/grpc-client": "^0.0.0",
-                "crc": "^4.3.2",
                 "express": "^5.2.1",
                 "express-prom-bundle": "^7.0.2",
                 "express-rate-limit": "^8.2.1",
@@ -6813,22 +6811,6 @@
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "license": "MIT"
-        },
-        "node_modules/crc": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/crc/-/crc-4.3.2.tgz",
-            "integrity": "sha512-uGDHf4KLLh2zsHa8D8hIQ1H/HtFQhyHrc0uhHBcoKGol/Xnb+MPYfUMw7cvON6ze/GUESTudKayDcJC5HnJv1A==",
-            "engines": {
-                "node": ">=12"
-            },
-            "peerDependencies": {
-                "buffer": ">=6.0.3"
-            },
-            "peerDependenciesMeta": {
-                "buffer": {
-                    "optional": true
-                }
-            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
                 "@hey-api/openapi-ts": "^0.95.0",
                 "@imagemagick/magick-wasm": "^0.0.38",
                 "@neato/config": "^4.1.0",
-                "@pretendonetwork/grpc": "^2.4.3",
+                "@pretendonetwork/grpc": "^2.5.3",
                 "@repo/grpc-client": "^0.0.0",
                 "classnames": "^2.5.1",
                 "connect-redis": "^9.0.0",


### PR DESCRIPTION
Changes:
- Update as much as possible to use V2 GRPC methods, with a couple exceptions:
  - `getPNID()` on v2 account is not implemented. So it's using the deprecated `getUserData()`
  - Friends is hard to selfhost locally because of the new encryption keys. So it's gonna stay on v1 so local testing is possible.
- Replaced decrypting service tokens with the new `exchangeIndependentServiceTokenForUserData()`
- Removed unused packages related to decrypting tokens
- Removed unused types related to decrypting tokens

Notes:
- Web has been tested. So that's all the GRPC updates
- Service tokens have not been tested, I don't have a console set up. Hoping to get some staff to test it on dev.

Resolves currently broken production issues due to updated token format.

resolves #111 
