### PR TITLE
Fix "Null" Embed Text on Posts Without Text

### DIFF
--- a/apps/juxtaposition-ui/src/services/juxt-web/views/web/postPageView.tsx
+++ b/apps/juxtaposition-ui/src/services/juxt-web/views/web/postPageView.tsx
@@ -32,7 +32,7 @@ function PostHead(props: PostPageViewProps): ReactNode {
 	}
 
 	const title = `${post.author.miiName} (@${props.postPNID.username}) - ${props.community.name}`;
-	const description = post.body + '\n\n' +
+	const description = `${post.body ?? ''}` + '\n\n' +
 		`${post.stats.replyCount} 🗨️  ${post.stats.empathyCount} ❤️`;
 	let image: string | null = null;
 	if (post.screenshot) {


### PR DESCRIPTION
Resolves #575 

### Changes:

Changed post description to use an empty string in the case of a post not having any text.

- [X] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [X] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [X] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [X] I have tested all of my changes.