### PR TITLE
fix(ctr): un-break notification count

### DIFF
--- a/apps/juxtaposition-ui/webfiles/ctr/js/juxt.js
+++ b/apps/juxtaposition-ui/webfiles/ctr/js/juxt.js
@@ -98,8 +98,7 @@ function initAll() {
 function checkForUpdates() {
 	GET('/users/notifications.json', function updates(data) {
 		var notificationObj = JSON.parse(data.responseText);
-		var count =
-			notificationObj.message_count + notificationObj.notification_count;
+		var count = notificationObj.notification_count;
 		cave.toolbar_setNotificationCount(count);
 	});
 }


### PR DESCRIPTION
Apparently this was broken since the removal of DMs. OOPS

<!--

* Before making a pull request, ensure the changes are for an approved issue.
* If your changes are not for an approved issue, your pull request can and will be rejected.
*
* CHECK https://github.com/PretendoNetwork/REPO_NAME/issues?q=is%3Aopen+is%3Aissue+label%3Aapproved
* FOR APPROVED ISSUES!

-->

Resolves #XXX

### Changes:

The notification counter broke on CTR when we removed DMs, since it was adding the notification and messages count together. NaN + whatever = NaN, so we lost it in the wash. :(

Fix that and bring back the notification counter.

<!--

* Describe your changes in as much detail as possible. Make sure to list your changes, as well as the rationale behind them.
* If applicable, include code snippets, images, videos, etc.
*
* If your changes require any database migrations, describe them in detail and leave any migration queries inside of a code
* block within a <details> tag.

-->

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.